### PR TITLE
요청 연월에 등록된 블로그 글이 web archive에 없는 경우를 처리할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	testImplementation 'org.wiremock:wiremock-standalone:3.12.1'
 }
 
 tasks.named('test') {

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value

--- a/src/main/java/org/gsh/genidxpage/config/CustomRestTemplateBuilder.java
+++ b/src/main/java/org/gsh/genidxpage/config/CustomRestTemplateBuilder.java
@@ -1,0 +1,14 @@
+package org.gsh.genidxpage.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+
+import java.time.Duration;
+
+public class CustomRestTemplateBuilder {
+    public static RestTemplateBuilder get() {
+        return new RestTemplateBuilder()
+                .readTimeout(Duration.ofSeconds(15L))
+                .connectTimeout(Duration.ofSeconds(15L))
+                .errorHandler(new CustomRestTemplateErrorHandler());
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/config/CustomRestTemplateErrorHandler.java
+++ b/src/main/java/org/gsh/genidxpage/config/CustomRestTemplateErrorHandler.java
@@ -1,0 +1,15 @@
+package org.gsh.genidxpage.config;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class CustomRestTemplateErrorHandler extends DefaultResponseErrorHandler {
+
+    @Override
+    public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -1,0 +1,22 @@
+package org.gsh.genidxpage.service;
+
+import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
+import org.gsh.genidxpage.service.dto.FindBlogPostDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class WebArchiveApiCaller {
+    private final RestTemplate restTemplate;
+
+    public WebArchiveApiCaller(@Value("${webArchive.rootUri}") final String rootUri) {
+        RestTemplate restTemplate = CustomRestTemplateBuilder.get().rootUri(rootUri).build();
+        this.restTemplate = restTemplate;
+    }
+
+    public ResponseEntity<String> findBlogPost(final String restUrl, final FindBlogPostDto dto) {
+        return restTemplate.getForEntity(restUrl, String.class, dto.getYear(), dto.getMonth());
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/dto/FindBlogPostDto.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/FindBlogPostDto.java
@@ -1,0 +1,19 @@
+package org.gsh.genidxpage.service.dto;
+
+public class FindBlogPostDto {
+    private final String year;
+    private final String month;
+
+    public FindBlogPostDto(String year, String month) {
+        this.year = year;
+        this.month = month;
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -1,0 +1,28 @@
+package org.gsh.genidxpage.web;
+
+import org.gsh.genidxpage.service.WebArchiveApiCaller;
+import org.gsh.genidxpage.service.dto.FindBlogPostDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ResponseBody
+@Controller
+public class ArchivePageController {
+    private final WebArchiveApiCaller webArchiveApiCaller;
+
+    public ArchivePageController(final WebArchiveApiCaller webArchiveApiCaller) {
+        this.webArchiveApiCaller = webArchiveApiCaller;
+    }
+
+    @GetMapping("/posts/{year}/{month}")
+    public ResponseEntity<String> getBlogPost(@PathVariable(value="year") String year,
+                                              @PathVariable(value="month") String month) {
+        FindBlogPostDto dto = new FindBlogPostDto(year, month);
+        ResponseEntity<String> response = webArchiveApiCaller.findBlogPost("/posts/{year}/{month}", dto);
+        return ResponseEntity.status(response.getStatusCode())
+                .body(response.getBody());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: genidxpage
+webArchive:
+  rootUri: x

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -1,0 +1,43 @@
+package org.gsh.genidxpage;
+
+import com.github.tomakehurst.wiremock.http.Body;
+import org.assertj.core.api.Assertions;
+import org.gsh.genidxpage.service.WebArchiveApiCaller;
+import org.gsh.genidxpage.web.ArchivePageController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class AcceptanceTest {
+
+    @DisplayName("요청 연월에 등록된 블로그 글이 web archive에 없으면, 리소스가 존재하지 않음을 응답으로 받는다")
+    @Test
+    public void receive_not_found_msg_when_send_request() {
+        ArchivePageController archivePageController = new ArchivePageController(
+                new WebArchiveApiCaller("http://localhost:8080")
+        );
+
+        FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
+
+        fakeWebArchiveServer.instance.stubFor(get(urlPathTemplate("/posts/{year}/{month}"))
+                .withPathParam("year", equalTo("1999"))
+                .withPathParam("month", equalTo("7"))
+                .willReturn(aResponse().withStatus(500).withResponseBody(
+                        Body.fromOneOf(null, "resource not found", null, null)
+                )));
+
+        fakeWebArchiveServer.start();
+
+        // 서버는 web archive server에 아카이브된 블로그 글을 요청한다
+        ResponseEntity<String> response = archivePageController.getBlogPost("1999", "7");
+
+        // web archive server는 처리할 수 없음 메시지를 반환한다
+        // 서버는 처리할 수 없는 요청임을 클라이언트에게 알린다
+        Assertions.assertThat(response.getBody()).isEqualTo("resource not found");
+        Assertions.assertThat(response.getStatusCode().is5xxServerError()).isTrue();
+
+        fakeWebArchiveServer.stop();
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -1,0 +1,21 @@
+package org.gsh.genidxpage;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+class FakeWebArchiveServer {
+    WireMockServer instance;
+
+    public FakeWebArchiveServer() {
+        this.instance = new WireMockServer(wireMockConfig().port(8080));
+    }
+
+    public void start() {
+        this.instance.start();
+    }
+
+    public void stop() {
+        this.instance.stop();
+    }
+}


### PR DESCRIPTION
- 구현하려는 상황에 대한 인수 테스트를 추가한다
  - FakeWebArchiveServer는 wiremock server의 wrapper class로,
  테스트에서 web archive 서버를 대신한다
- 외부 api 호출 시 쓸 restTemplate 설정한다
  - CustomRestTemplateBuilder은 공통 restTemplate 설정값을 갖는다
  - CustomRestTemplateErrorHandler은 외부 api에 요청한 결과가
  4xx/5xx일 때 restTemplate에서 (기본 동작 방식인) 예외 대신
  http response를 반환하도록 하기 위해 정의한다
- 인수 테스트를 통과하도록 코드 구현한다