### PR TITLE
chore: 브랜치명 규칙이 맞지 않으면 push를 막는다

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+now_branch_nm = `git rev-parse --abbrev-ref HEAD`
+branch_nm_convention = /^issue\/[1-9][0-9]*(\w|-)+/
+
+if now_branch_nm.match(branch_nm_convention).nil?
+  puts 'branch name does not follow the convention!'
+  puts 'it should match "issue/80-blah-blah"'
+  exit 1
+end
+


### PR DESCRIPTION
- hooks 디렉토리가 git hook 디렉토리로 설정되어야 한다
- 이 명령으로 설정: `git config core.hooksPath hooks`
- https://stackoverflow.com/a/37861972