### PR TITLE
push할 때 checkstyle task를 실행한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,4 +35,5 @@ checkstyle {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	jvmArgs '-Xshare:off'
 }

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -10,8 +10,11 @@ if now_branch_nm.match(branch_nm_convention).nil?
 end
 
 checkstyle_result = `./gradlew checkstyleMain checkstyleTest 2>/dev/null`
-is_failed = checkstyle_result.split("\n").select {|l| l.match(/^> Task :checkstyleMain FAILED.*|^> Task :checkstyleTest FAILED.*/)}
-if is_failed != []
+is_checkstyle_failed = checkstyle_result.split("\n")
+  .select {|l|
+    l.match(/^> Task :checkstyleMain FAILED.*|^> Task :checkstyleTest FAILED.*/)
+  } != []
+if is_checkstyle_failed
   puts 'failed to format code as configured in checkstyle!'
   puts 'run ./gradlew check for detail'
   exit 1

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -9,3 +9,11 @@ if now_branch_nm.match(branch_nm_convention).nil?
   exit 1
 end
 
+checkstyle_result = `./gradlew checkstyleMain checkstyleTest 2>/dev/null`
+is_failed = checkstyle_result.split("\n").select {|l| l.match(/^> Task :checkstyleMain FAILED.*|^> Task :checkstyleTest FAILED.*/)}
+if is_failed != []
+  puts 'failed to format code as configured in checkstyle!'
+  puts 'run ./gradlew check for detail'
+  exit 1
+end
+


### PR DESCRIPTION
* checkstyle task 실패 시 push를 막는다
  - pre-push 훅 실행 시 checkstyle task 실패 여부만 알 수 있게 하고, 세부
    사항은 gradle task를 직접 실행해서 알 수 있도록 한다

* jdk 경고 메시지가 뜨지 않게 한다
  - 빌드 시 뜨는 다음 경고 메시지가 나타나지 않게 한다
  - OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot
    loader classes because bootstrap classpath has been appended
  - ref: https://github.com/mockito/mockito/issues/3111
