### PR TITLE
하나의 연월에 등록된 여러 블로그 글의 링크 목록을 가져올 수 있다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
@@ -5,12 +5,22 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public class WebPageParser {
 
-    public PostLinkInfo findPostLinks(String stringDoc) {
+    public List<PostLinkInfo> findPostLinks(String stringDoc) {
         Document doc = Jsoup.parse(stringDoc);
         Elements postLinks = doc.select(".POST_BODY > a");
-        return new PostLinkInfo(postLinks.get(0));
+
+        List<PostLinkInfo> result = new ArrayList<>();
+        for (Element postLink : postLinks) {
+            result.add(new PostLinkInfo(postLink));
+        }
+
+        return Collections.unmodifiableList(result);
     }
 
     public class PostLinkInfo {

--- a/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
@@ -26,6 +26,16 @@ public class WebPageParser {
         return Collections.unmodifiableList(result);
     }
 
+    public String buildPageLinks(List<PostLinkInfo> postLinks) {
+        StringBuilder result = new StringBuilder();
+        for (PostLinkInfo postLink : postLinks) {
+            result.append(postLink.buildPageLink());
+            result.append("\n");
+        }
+        result.deleteCharAt(result.length() - 1);
+        return result.toString();
+    }
+
     public class PostLinkInfo {
 
         private final String baseUrl = "https://web.archive.org";

--- a/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
@@ -2,12 +2,38 @@ package org.gsh.genidxpage.service;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 public class WebPageParser {
 
-    public Elements findPostLinks(String stringDoc) {
+    public PostLinkInfo findPostLinks(String stringDoc) {
         Document doc = Jsoup.parse(stringDoc);
-        return doc.select(".POST_BODY > a");
+        Elements postLinks = doc.select(".POST_BODY > a");
+        return new PostLinkInfo(postLinks.get(0));
+    }
+
+    public class PostLinkInfo {
+
+        private final String baseUrl = "https://web.archive.org";
+        private String pageUrl;
+        private String pageTitle;
+
+        public PostLinkInfo(Element postLink) {
+            this.pageUrl = postLink.attribute("href").getValue();
+            this.pageTitle = postLink.text();
+        }
+
+        public String getPageUrl() {
+            return pageUrl;
+        }
+
+        public String getPageTitle() {
+            return pageTitle;
+        }
+
+        public String buildPageLink() {
+            return String.format("<a href=\"%s%s\">%s</a>", baseUrl, pageUrl, pageTitle);
+        }
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
@@ -17,7 +17,10 @@ public class WebPageParser {
 
         List<PostLinkInfo> result = new ArrayList<>();
         for (Element postLink : postLinks) {
-            result.add(new PostLinkInfo(postLink));
+            result.add(new PostLinkInfo(
+                postLink.attribute("href").getValue(),
+                postLink.text()
+            ));
         }
 
         return Collections.unmodifiableList(result);
@@ -29,9 +32,9 @@ public class WebPageParser {
         private String pageUrl;
         private String pageTitle;
 
-        public PostLinkInfo(Element postLink) {
-            this.pageUrl = postLink.attribute("href").getValue();
-            this.pageTitle = postLink.text();
+        public PostLinkInfo(String pageUrl, String pageTitle) {
+            this.pageUrl = pageUrl;
+            this.pageTitle = pageTitle;
         }
 
         public String getPageUrl() {

--- a/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
@@ -1,5 +1,6 @@
 package org.gsh.genidxpage.service;
 
+import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -36,27 +37,4 @@ public class WebPageParser {
         return result.toString();
     }
 
-    public class PostLinkInfo {
-
-        private final String baseUrl = "https://web.archive.org";
-        private String pageUrl;
-        private String pageTitle;
-
-        public PostLinkInfo(String pageUrl, String pageTitle) {
-            this.pageUrl = pageUrl;
-            this.pageTitle = pageTitle;
-        }
-
-        public String getPageUrl() {
-            return pageUrl;
-        }
-
-        public String getPageTitle() {
-            return pageTitle;
-        }
-
-        public String buildPageLink() {
-            return String.format("<a href=\"%s%s\">%s</a>", baseUrl, pageUrl, pageTitle);
-        }
-    }
 }

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.List;
+
 @ResponseBody
 @Controller
 public class ArchivePageController {
@@ -40,8 +42,8 @@ public class ArchivePageController {
         String blogPost = blogPostResponse.getBody();
 
         WebPageParser webPageParser = new WebPageParser();
-        PostLinkInfo postLinks = webPageParser.findPostLinks(blogPost);
-        String pageLink = postLinks.buildPageLink();
+        List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
+        String pageLink = postLinks.get(0).buildPageLink();
 
         return ResponseEntity.status(blogPostResponse.getStatusCode())
             .body(pageLink);

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -2,9 +2,9 @@ package org.gsh.genidxpage.web;
 
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.WebPageParser;
+import org.gsh.genidxpage.service.WebPageParser.PostLinkInfo;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
-import org.jsoup.select.Elements;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -40,12 +40,8 @@ public class ArchivePageController {
         String blogPost = blogPostResponse.getBody();
 
         WebPageParser webPageParser = new WebPageParser();
-        Elements postLinks = webPageParser.findPostLinks(blogPost);
-
-        String baseUrl = "https://web.archive.org";
-        String pageUrl = postLinks.get(0).attribute("href").getValue();
-        String pageTitle = postLinks.get(0).text();
-        String pageLink = String.format("<a href=\"%s%s\">%s</a>", baseUrl, pageUrl, pageTitle);
+        PostLinkInfo postLinks = webPageParser.findPostLinks(blogPost);
+        String pageLink = postLinks.buildPageLink();
 
         return ResponseEntity.status(blogPostResponse.getStatusCode())
             .body(pageLink);

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -2,9 +2,9 @@ package org.gsh.genidxpage.web;
 
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.WebPageParser;
-import org.gsh.genidxpage.service.WebPageParser.PostLinkInfo;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -22,8 +22,8 @@ public class ArchivePageController {
         this.webArchiveApiCaller = webArchiveApiCaller;
     }
 
-    @GetMapping("/post-lists/{year}/{month}")
-    public ResponseEntity<String> getBlogPostListPage(
+    @GetMapping("/post-links/{year}/{month}")
+    public ResponseEntity<String> getBlogPostLinks(
         @PathVariable(value = "year") String year,
         @PathVariable(value = "month") String month
     ) {

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -43,9 +43,9 @@ public class ArchivePageController {
 
         WebPageParser webPageParser = new WebPageParser();
         List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
-        String pageLink = postLinks.get(0).buildPageLink();
+        String pageLinks = webPageParser.buildPageLinks(postLinks);
 
         return ResponseEntity.status(blogPostResponse.getStatusCode())
-            .body(pageLink);
+            .body(pageLinks);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/web/response/PostLinkInfo.java
+++ b/src/main/java/org/gsh/genidxpage/web/response/PostLinkInfo.java
@@ -1,0 +1,25 @@
+package org.gsh.genidxpage.web.response;
+
+public class PostLinkInfo {
+
+    private final String baseUrl = "https://web.archive.org";
+    private String pageUrl;
+    private String pageTitle;
+
+    public PostLinkInfo(String pageUrl, String pageTitle) {
+        this.pageUrl = pageUrl;
+        this.pageTitle = pageTitle;
+    }
+
+    public String getPageUrl() {
+        return pageUrl;
+    }
+
+    public String getPageTitle() {
+        return pageTitle;
+    }
+
+    public String buildPageLink() {
+        return String.format("<a href=\"%s%s\">%s</a>", baseUrl, pageUrl, pageTitle);
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -48,7 +48,7 @@ public class AcceptanceTest {
         FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
         fakeWebArchiveServer.respondItHasArchivedPage();
-        fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "3");
+        fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "3", false);
 
         fakeWebArchiveServer.start();
 

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -26,7 +26,7 @@ public class AcceptanceTest {
         fakeWebArchiveServer.start();
 
         // 서버는 web archive server에 아카이브된 블로그 글을 요청한다
-        ResponseEntity<String> response = archivePageController.getBlogPostListPage("1999", "7");
+        ResponseEntity<String> response = archivePageController.getBlogPostLinks("1999", "7");
 
         // web archive server는 처리할 수 없음 메시지를 반환한다
         // 서버는 처리할 수 없는 요청임을 클라이언트에게 알린다
@@ -53,7 +53,7 @@ public class AcceptanceTest {
         fakeWebArchiveServer.start();
 
         // 서버는 web archive server에 아카이브된 주어진 연월의 블로그 글 목록 페이지를 요청한다
-        ResponseEntity<String> response = archivePageController.getBlogPostListPage("2021", "3");
+        ResponseEntity<String> response = archivePageController.getBlogPostLinks("2021", "3");
 
         // web archive server는 주어진 연월의 블로그 글 목록 페이지를 반환한다
         Assertions.assertThat(response.getBody()).isEqualTo(

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -63,4 +63,34 @@ public class AcceptanceTest {
 
         fakeWebArchiveServer.stop();
     }
+
+    @DisplayName("요청 연월에 등록된 블로그 글이 여러 개면, 해당 블로그 글에 접근할 수 있는 링크 목록을 응답으로 받는다")
+    @Test
+    public void receive_post_link_list_when_multiple_posts_exists() {
+        ArchivePageController archivePageController = new ArchivePageController(
+            new WebArchiveApiCaller("http://localhost:8080",
+                "/wayback/available?url={url}&timestamp={timestamp}",
+                CustomRestTemplateBuilder.get())
+        );
+
+        FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
+
+        fakeWebArchiveServer.respondItHasArchivedPage();
+        fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "3", true);
+
+        fakeWebArchiveServer.start();
+
+        // 서버는 web archive server에 아카이브된 주어진 연월의 블로그 글 목록 페이지를 요청한다
+        ResponseEntity<String> response = archivePageController.getBlogPostLinks("2021", "3");
+
+        // web archive server는 주어진 연월의 블로그 글 목록 페이지를 반환한다
+        Assertions.assertThat(response.getBody()).isEqualTo(
+            "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">올해 첫 AC2 과정 40기가 곧 열립니다</a>%n"
+                + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>%n"
+                + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
+        );
+        Assertions.assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+        fakeWebArchiveServer.stop();
+    }
 }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -85,8 +85,8 @@ public class AcceptanceTest {
 
         // web archive server는 주어진 연월의 블로그 글 목록 페이지를 반환한다
         Assertions.assertThat(response.getBody()).isEqualTo(
-            "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">올해 첫 AC2 과정 40기가 곧 열립니다</a>%n"
-                + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>%n"
+            "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">올해 첫 AC2 과정 40기가 곧 열립니다</a>\n"
+                + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>\n"
                 + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
         );
         Assertions.assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -24,7 +24,8 @@ public class FakeWebArchiveServer {
         this.instance.stop();
     }
 
-    public void respondBlogPostListInGivenYearMonth(String year, String month, boolean hasManyPost) {
+    public void respondBlogPostListInGivenYearMonth(String year, String month,
+        boolean hasManyPost) {
         instance.stubFor(get(urlPathTemplate("/web/20230614220926/archives/{year}/{month}"))
             .withPathParam("year", equalTo(year))
             .withPathParam("month", equalTo(String.format("%02d", Integer.parseInt(month))))

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -24,46 +24,60 @@ public class FakeWebArchiveServer {
         this.instance.stop();
     }
 
-    public void respondBlogPostListInGivenYearMonth(String year, String month) {
+    public void respondBlogPostListInGivenYearMonth(String year, String month, boolean hasManyPost) {
         instance.stubFor(get(urlPathTemplate("/post-links/{year}/{month}"))
             .withPathParam("year", equalTo(year))
             .withPathParam("month", equalTo(month))
             .willReturn(aResponse().withStatus(200)
                 .withBody(
-                    """
-                        <html>
-                        <table border="0" cellpadding="0" cellspacing="0" align="CENTER" width="100%">
-                          <tr><td valign="TOP" width="90%">
-                            <div id="LEFT">
-                              <!-- egloos content start -->
-                              <div class="POST">
-                                <div class="POST_HEAD">
-                                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                    <tr><td width="80%"><div class="POST_TTL">2021년 03월 전체 글 목록</div></td>
-                                      <td width="20%" align="RIGHT"></td></tr>
-                                  </table>
-                                </div>
-                                <div class="POST_BODY">
-                                  <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">올해 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
-                                  <div style="margin-top:10px;"><a href="/web/20230614220926/http://agile.egloos.com/archives/2021/03/page/1" title="전체보기">"2021년03월" 의 글 내용 전체 보기</a></div>
-                                </div>
-                                <div class="POST_TAIL"></div>
-
-                              </div><!-- egloos content end -->
-                              <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                <tr><td align="RIGHT" width="48%">&lt; 이전페이지</td><td width="4%"></td>
-                                  <td align="LEFT" width="48%">다음페이지 &gt;</td></tr>
-                              </table>
-                              <br><br>
-                            </div>
-                          </td>
-                        </table>
-                        </html>
-                        """
+                    buildPostListPage(hasManyPost)
                 )
             )
         );
     }
+
+    private String buildPostListPage(boolean hasManyPost) {
+        String postListPageHead = """
+            <html>
+            <table border="0" cellpadding="0" cellspacing="0" align="CENTER" width="100%">
+              <tr><td valign="TOP" width="90%">
+                <div id="LEFT">
+                  <!-- egloos content start -->
+                  <div class="POST">
+                    <div class="POST_HEAD">
+                      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                        <tr><td width="80%"><div class="POST_TTL">2021년 03월 전체 글 목록</div></td>
+                          <td width="20%" align="RIGHT"></td></tr>
+                      </table>
+                    </div>
+                    <div class="POST_BODY">
+            """;
+        String postListPageTail = """
+                      <div style="margin-top:10px;"><a href="/web/20230614220926/http://agile.egloos.com/archives/2021/03/page/1" title="전체보기">"2021년03월" 의 글 내용 전체 보기</a></div>
+                    </div>
+                    <div class="POST_TAIL"></div>
+
+                  </div><!-- egloos content end -->
+                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                    <tr><td align="RIGHT" width="48%">&lt; 이전페이지</td><td width="4%"></td>
+                      <td align="LEFT" width="48%">다음페이지 &gt;</td></tr>
+                  </table>
+                  <br><br>
+                </div>
+              </td>
+            </table>
+            </html>
+            """;
+
+        String firstPost = """
+                <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">올해 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
+            """;
+        if (hasManyPost) {
+            return "";
+        }
+        return postListPageHead + firstPost + postListPageTail;
+    }
+
 
     public void respondItHasArchivedPage() {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -25,7 +25,7 @@ public class FakeWebArchiveServer {
     }
 
     public void respondBlogPostListInGivenYearMonth(String year, String month) {
-        instance.stubFor(get(urlPathTemplate("/post-lists/{year}/{month}"))
+        instance.stubFor(get(urlPathTemplate("/post-links/{year}/{month}"))
             .withPathParam("year", equalTo(year))
             .withPathParam("month", equalTo(month))
             .willReturn(aResponse().withStatus(200)

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -72,8 +72,12 @@ public class FakeWebArchiveServer {
         String firstPost = """
                 <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">올해 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
             """;
+        String otherPosts = """
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/27</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
+            """;
         if (hasManyPost) {
-            return "";
+            return postListPageHead + firstPost + otherPosts + postListPageTail;
         }
         return postListPageHead + firstPost + postListPageTail;
     }

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -25,13 +25,13 @@ public class FakeWebArchiveServer {
     }
 
     public void respondBlogPostListInGivenYearMonth(String year, String month, boolean hasManyPost) {
-        instance.stubFor(get(urlPathTemplate("/post-links/{year}/{month}"))
+        instance.stubFor(get(urlPathTemplate("/web/20230614220926/archives/{year}/{month}"))
             .withPathParam("year", equalTo(year))
-            .withPathParam("month", equalTo(month))
+            .withPathParam("month", equalTo(String.format("%02d", Integer.parseInt(month))))
             .willReturn(aResponse().withStatus(200)
                 .withBody(
                     buildPostListPage(hasManyPost)
-                )
+                ).withHeader("Content-Type", "text/html; charset=utf-8")
             )
         );
     }
@@ -95,7 +95,7 @@ public class FakeWebArchiveServer {
                             "closest": {
                               "status": "200",
                               "available": true,
-                              "url": "http://web.archive.org/web/20230614220926/http://agile.egloos.com/archives/2021/03",
+                              "url": "http://localhost:8080/web/20230614220926/archives/2021/03",
                               "timestamp": "20230614220926"
                             }
                           },

--- a/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
@@ -1,7 +1,7 @@
 package org.gsh.genidxpage.service;
 
 import org.assertj.core.api.Assertions;
-import org.jsoup.select.Elements;
+import org.gsh.genidxpage.service.WebPageParser.PostLinkInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -19,11 +19,11 @@ public class WebPageParserTest {
         Path path = Paths.get("src/test/resources/2021-03-full-response.html");
         String fileContent = Files.readString(path, StandardCharsets.UTF_8);
         WebPageParser webPageParser = new WebPageParser();
-        Elements resultDivs = webPageParser.findPostLinks(fileContent);
+        PostLinkInfo postLinks = webPageParser.findPostLinks(fileContent);
 
-        Assertions.assertThat(resultDivs.get(0).text())
+        Assertions.assertThat(postLinks.getPageTitle())
             .isEqualTo("올해 첫 AC2 과정 40기가 곧 열립니다");
-        Assertions.assertThat(resultDivs.get(0).attribute("href").getValue())
+        Assertions.assertThat(postLinks.getPageUrl())
             .isEqualTo("/web/20230614220926/http://agile.egloos.com/5946833");
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
@@ -15,15 +15,15 @@ public class WebPageParserTest {
 
     @DisplayName("문자열로 된 블로그 글 목록 html 페이지로부터 태그 규칙에 맞는 html 요소를 검색할 수 있다")
     @Test
-    public void find_matching_html_elems_from_post_list_html_page_string() throws IOException {
+    public void find_matching_html_elem_from_post_list_html_page_string() throws IOException {
         Path path = Paths.get("src/test/resources/2021-03-full-response.html");
         String fileContent = Files.readString(path, StandardCharsets.UTF_8);
         WebPageParser webPageParser = new WebPageParser();
-        PostLinkInfo postLinks = webPageParser.findPostLinks(fileContent);
+        PostLinkInfo postLink = webPageParser.findPostLinks(fileContent).get(0);
 
-        Assertions.assertThat(postLinks.getPageTitle())
+        Assertions.assertThat(postLink.getPageTitle())
             .isEqualTo("올해 첫 AC2 과정 40기가 곧 열립니다");
-        Assertions.assertThat(postLinks.getPageUrl())
+        Assertions.assertThat(postLink.getPageUrl())
             .isEqualTo("/web/20230614220926/http://agile.egloos.com/5946833");
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
@@ -1,7 +1,7 @@
 package org.gsh.genidxpage.service;
 
 import org.assertj.core.api.Assertions;
-import org.gsh.genidxpage.service.WebPageParser.PostLinkInfo;
+import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
@@ -42,4 +42,26 @@ public class WebPageParserTest {
             Assertions.assertThat(postLink.getPageUrl()).isNotNull();
         }
     }
+
+    @DisplayName("클라이언트에 돌려줄 형태로 html 요소 검색 결과를 변환할 수 있다")
+    @Test
+    public void convert_matching_html_elems_for_client() throws IOException {
+        WebPageParser webPageParser = new WebPageParser();
+
+        Path path = Paths.get("src/test/resources/2021-03-full-response.html");
+        String fileContent = Files.readString(path, StandardCharsets.UTF_8);
+        List<PostLinkInfo> postLinks = webPageParser.findPostLinks(fileContent);
+        Assertions.assertThat(webPageParser.buildPageLinks(postLinks)).isEqualTo(
+            "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">올해 첫 AC2 과정 40기가 곧 열립니다</a>"
+        );
+
+        Path path2 = Paths.get("src/test/resources/2020-02-response.html");
+        String fileContent2 = Files.readString(path2, StandardCharsets.UTF_8);
+        List<PostLinkInfo> postLinks2 = webPageParser.findPostLinks(fileContent2);
+        Assertions.assertThat(webPageParser.buildPageLinks(postLinks2)).isEqualTo(
+            "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>"
+                + "\n" +
+                "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
+        );
+    }
 }

--- a/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 public class WebPageParserTest {
 
@@ -25,5 +26,20 @@ public class WebPageParserTest {
             .isEqualTo("올해 첫 AC2 과정 40기가 곧 열립니다");
         Assertions.assertThat(postLink.getPageUrl())
             .isEqualTo("/web/20230614220926/http://agile.egloos.com/5946833");
+    }
+
+    @DisplayName("태그 규칙에 맞는 하나 이상의 html 요소를 검색할 수 있다")
+    @Test
+    public void find_matching_html_elems_from_post_list_html_page_string() throws IOException {
+        Path path = Paths.get("src/test/resources/2020-02-response.html");
+        String fileContent = Files.readString(path, StandardCharsets.UTF_8);
+        WebPageParser webPageParser = new WebPageParser();
+        List<PostLinkInfo> postLinks = webPageParser.findPostLinks(fileContent);
+
+        Assertions.assertThat(postLinks.size()).isGreaterThan(1);
+        for (PostLinkInfo postLink : postLinks) {
+            Assertions.assertThat(postLink.getPageTitle()).isNotNull();
+            Assertions.assertThat(postLink.getPageUrl()).isNotNull();
+        }
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
@@ -59,9 +59,8 @@ public class WebPageParserTest {
         String fileContent2 = Files.readString(path2, StandardCharsets.UTF_8);
         List<PostLinkInfo> postLinks2 = webPageParser.findPostLinks(fileContent2);
         Assertions.assertThat(webPageParser.buildPageLinks(postLinks2)).isEqualTo(
-            "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>"
-                + "\n" +
-                "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
+            "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>\n"
+                + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
         );
     }
 }

--- a/src/test/resources/2020-02-response.html
+++ b/src/test/resources/2020-02-response.html
@@ -14,26 +14,18 @@
         <div class="POST">
           <div class="POST_HEAD">
             <table border="0" cellpadding="0" cellspacing="0" width="100%">
-              <tr>
-                <td width="80%">
-                  <div class="POST_TTL">2021년 03월 전체 글 목록</div>
-                </td>
-                <td width="20%" align="RIGHT"></td>
-              </tr>
-            </table>
+              <tbody><tr><td width="80%"><div class="POST_TTL">2020년 02월 전체 글 목록</div></td>
+                <td width="20%" align="RIGHT"></td></tr>
+              </tbody></table>
           </div>
           <div class="POST_BODY">
-            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/22</span>
-            &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">올해 첫 AC2 과정 40기가 곧
-            열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;"
-                           class="archivedate">[3]</span><br/>
-            <div style="margin-top:10px;"><a
-                href="/web/20230614220926/http://agile.egloos.com/archives/2021/03/page/1"
-                title="전체보기">"2021년03월" 의 글 내용 전체 보기</a></div>
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/14</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
+            <div style="margin-top:10px;"><a href="/web/20230614124528/http://agile.egloos.com/archives/2020/02/page/1" title="전체보기">"2020년02월" 의 글 내용 전체 보기</a></div>
           </div>
           <div class="POST_TAIL"></div>
-
-        </div><!-- egloos content end -->
+        </div>
+        <!-- egloos content end -->
         <table border="0" cellpadding="0" cellspacing="0" width="100%">
           <tr>
             <td align="RIGHT" width="48%">&lt; 이전페이지</td>

--- a/src/test/resources/2020-02-response.html
+++ b/src/test/resources/2020-02-response.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+</head>
+<body>
+<iframe name="cmtviewfrm" id="cmtviewfrm" src="about:blank" width="0" height="0" frameborder="0"
+        scrolling="no" marginheight="0" marginwidth="0" style="display:block;border:0px;"></iframe>
+<link rel="me" type="text/html" href="http://www.google.com/profiles/juneaftn"/>
+
+<table border="0" cellpadding="0" cellspacing="0" align="CENTER" width="100%">
+  <tr>
+    <td valign="TOP" width="90%">
+      <div id="LEFT">
+        <!-- egloos content start -->
+        <div class="POST">
+          <div class="POST_HEAD">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tr>
+                <td width="80%">
+                  <div class="POST_TTL">2021년 03월 전체 글 목록</div>
+                </td>
+                <td width="20%" align="RIGHT"></td>
+              </tr>
+            </table>
+          </div>
+          <div class="POST_BODY">
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/22</span>
+            &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">올해 첫 AC2 과정 40기가 곧
+            열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;"
+                           class="archivedate">[3]</span><br/>
+            <div style="margin-top:10px;"><a
+                href="/web/20230614220926/http://agile.egloos.com/archives/2021/03/page/1"
+                title="전체보기">"2021년03월" 의 글 내용 전체 보기</a></div>
+          </div>
+          <div class="POST_TAIL"></div>
+
+        </div><!-- egloos content end -->
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+          <tr>
+            <td align="RIGHT" width="48%">&lt; 이전페이지</td>
+            <td width="4%"></td>
+            <td align="LEFT" width="48%">다음페이지 &gt;</td>
+          </tr>
+        </table>
+        <br><br>
+      </div>
+    </td>
+  </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
- http://web.archive.org/web/20230614124528/http://agile.egloos.com/archives/2020/02 와 같이 게시된 글이 여러 개인 글 목록 페이지에서 블로그 글의 링크 목록을 가져올 수 있다
- 컨트롤러에서 클라이언트로 문자열 형태 링크 목록을 반환한다. 이후에 반환 타입을 적용할 예정
- 인수 테스트 오류를 고친다