### PR TITLE
외부 서버 요청 결과를 db에 기록할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.jsoup:jsoup:1.19.1'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+    implementation 'com.mysql:mysql-connector-j'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
     implementation 'com.mysql:mysql-connector-j'
 
+    implementation 'org.slf4j:slf4j-api:2.0.13'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/org/gsh/genidxpage/common/exception/ErrorCode.java
+++ b/src/main/java/org/gsh/genidxpage/common/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package org.gsh.genidxpage.common.exception;
+
+public enum ErrorCode {
+
+    BAD_REQUEST("400", "잘못된 요청");
+
+    private final String code;
+    private final String reason;
+
+    ErrorCode(String code, String reason) {
+        this.code = code;
+        this.reason = reason;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
@@ -1,10 +1,13 @@
 package org.gsh.genidxpage.dao;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
 
 @Mapper
 public interface WebArchiveReportMapper {
 
     Long insertReport(ArchivedPageUrlReport report);
+
+    ArchivedPageUrlReport selectReportByYearMonth(@Param("year") String year, @Param("month") String month);
 }

--- a/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
@@ -1,0 +1,10 @@
+package org.gsh.genidxpage.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
+
+@Mapper
+public interface WebArchiveReportMapper {
+
+    Long insertReport(ArchivedPageUrlReport report);
+}

--- a/src/main/java/org/gsh/genidxpage/entity/ArchivedPageUrlReport.java
+++ b/src/main/java/org/gsh/genidxpage/entity/ArchivedPageUrlReport.java
@@ -16,6 +16,12 @@ public class ArchivedPageUrlReport {
 
     public ArchivedPageUrlReport() {}
 
+    public ArchivedPageUrlReport(String year, String month, Boolean pageExists) {
+        this.year = year;
+        this.month = month;
+        this.pageExists = pageExists;
+    }
+
     public ArchivedPageUrlReport(String year, String month, Boolean pageExists, LocalDateTime createdAt) {
         this.year = year;
         this.month = month;

--- a/src/main/java/org/gsh/genidxpage/entity/ArchivedPageUrlReport.java
+++ b/src/main/java/org/gsh/genidxpage/entity/ArchivedPageUrlReport.java
@@ -1,0 +1,50 @@
+package org.gsh.genidxpage.entity;
+
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+
+import java.time.LocalDateTime;
+
+public class ArchivedPageUrlReport {
+
+    private Long id;
+    private String year;
+    private String month;
+    private Boolean pageExists;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public ArchivedPageUrlReport() {}
+
+    public ArchivedPageUrlReport(String year, String month, Boolean pageExists, LocalDateTime createdAt) {
+        this.year = year;
+        this.month = month;
+        this.pageExists = pageExists;
+        this.createdAt = createdAt;
+    }
+
+    public static ArchivedPageUrlReport from(CheckPostArchivedDto dto, Boolean pageExists) {
+        return new ArchivedPageUrlReport(
+            dto.getYear(),
+            dto.getMonth(),
+            pageExists,
+            LocalDateTime.now()
+        );
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+
+    public Boolean getPageExists() {
+        return pageExists;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/exception/ArchivedPageNotFoundExceptioin.java
+++ b/src/main/java/org/gsh/genidxpage/exception/ArchivedPageNotFoundExceptioin.java
@@ -1,0 +1,19 @@
+package org.gsh.genidxpage.exception;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+
+public class ArchivedPageNotFoundExceptioin extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public ArchivedPageNotFoundExceptioin(ErrorCode errorCode, String message) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
@@ -1,0 +1,12 @@
+package org.gsh.genidxpage.service;
+
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiCallReporter {
+
+    public void reportArchivedPageSearch(final CheckPostArchivedDto dto) {
+
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
@@ -18,4 +18,13 @@ public class ApiCallReporter {
         ArchivedPageUrlReport report = ArchivedPageUrlReport.from(dto, pageExists);
         reportMapper.insertReport(report);
     }
+
+    public boolean hasArchivedPage(final CheckPostArchivedDto dto) {
+        ArchivedPageUrlReport report = reportMapper.selectReportByYearMonth(
+            dto.getYear(),
+            dto.getMonth()
+        );
+
+        return report.getPageExists() == Boolean.TRUE;
+    }
 }

--- a/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
@@ -1,12 +1,21 @@
 package org.gsh.genidxpage.service;
 
+import org.gsh.genidxpage.dao.WebArchiveReportMapper;
+import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ApiCallReporter {
 
-    public void reportArchivedPageSearch(final CheckPostArchivedDto dto) {
+    private final WebArchiveReportMapper reportMapper;
 
+    public ApiCallReporter(WebArchiveReportMapper reportMapper) {
+        this.reportMapper = reportMapper;
+    }
+
+    public void reportArchivedPageSearch(final CheckPostArchivedDto dto, final Boolean pageExists) {
+        ArchivedPageUrlReport report = ArchivedPageUrlReport.from(dto, pageExists);
+        reportMapper.insertReport(report);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -4,6 +4,7 @@ import org.gsh.genidxpage.common.exception.ErrorCode;
 import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.springframework.http.ResponseEntity;
 
 public class ArchivePageService {
 
@@ -21,5 +22,11 @@ public class ArchivePageService {
         }
 
         return archivedPageInfo;
+    }
+
+    public String findBlogPostPage(ArchivedPageInfo archivedPageInfo) {
+        ResponseEntity<String> blogPostResponse = webArchiveApiCaller.findBlogPostPage(
+            archivedPageInfo);
+        return blogPostResponse.getBody();
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -13,11 +13,11 @@ import java.util.List;
 @Service
 public class ArchivePageService {
 
+    private final WebArchiveApiCaller webArchiveApiCaller;
+
     public ArchivePageService(WebArchiveApiCaller webArchiveApiCaller) {
         this.webArchiveApiCaller = webArchiveApiCaller;
     }
-
-    private final WebArchiveApiCaller webArchiveApiCaller;
 
     public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -25,7 +25,7 @@ public class ArchivePageService {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
 
         if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
-            reporter.reportArchivedPageSearch(dto);
+            reporter.reportArchivedPageSearch(dto, Boolean.FALSE);
             throw new ArchivedPageNotFoundExceptioin(ErrorCode.BAD_REQUEST, "resource not found");
         }
 

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -29,6 +29,7 @@ public class ArchivePageService {
             throw new ArchivedPageNotFoundExceptioin(ErrorCode.BAD_REQUEST, "resource not found");
         }
 
+        reporter.reportArchivedPageSearch(dto, Boolean.TRUE);
         return archivedPageInfo;
     }
 

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -4,7 +4,10 @@ import org.gsh.genidxpage.common.exception.ErrorCode;
 import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 public class ArchivePageService {
 
@@ -28,5 +31,11 @@ public class ArchivePageService {
         ResponseEntity<String> blogPostResponse = webArchiveApiCaller.findBlogPostPage(
             archivedPageInfo);
         return blogPostResponse.getBody();
+    }
+
+    public String buildPageLinks(String blogPost) {
+        WebPageParser webPageParser = new WebPageParser();
+        List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
+        return webPageParser.buildPageLinks(postLinks);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -1,0 +1,25 @@
+package org.gsh.genidxpage.service;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
+import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+
+public class ArchivePageService {
+
+    public ArchivePageService(WebArchiveApiCaller webArchiveApiCaller) {
+        this.webArchiveApiCaller = webArchiveApiCaller;
+    }
+
+    private final WebArchiveApiCaller webArchiveApiCaller;
+
+    public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
+        ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
+
+        if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
+            throw new ArchivedPageNotFoundExceptioin(ErrorCode.BAD_REQUEST, "resource not found");
+        }
+
+        return archivedPageInfo;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -14,15 +14,18 @@ import java.util.List;
 public class ArchivePageService {
 
     private final WebArchiveApiCaller webArchiveApiCaller;
+    private final ApiCallReporter reporter;
 
-    public ArchivePageService(WebArchiveApiCaller webArchiveApiCaller) {
+    public ArchivePageService(WebArchiveApiCaller webArchiveApiCaller, ApiCallReporter reporter) {
         this.webArchiveApiCaller = webArchiveApiCaller;
+        this.reporter = reporter;
     }
 
     public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
 
         if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
+            reporter.reportArchivedPageSearch(dto);
             throw new ArchivedPageNotFoundExceptioin(ErrorCode.BAD_REQUEST, "resource not found");
         }
 

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -6,9 +6,11 @@ import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class ArchivePageService {
 
     public ArchivePageService(WebArchiveApiCaller webArchiveApiCaller) {

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -5,12 +5,12 @@ import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@Service
+@Component
 public class WebArchiveApiCaller {
 
     private final RestTemplate restTemplate;

--- a/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
@@ -58,6 +58,16 @@ public class ArchivedPageInfo {
             return this;
         }
 
+        public ArchivedPageInfoBuilder withAccessibleArchivedSnapshots() {
+            this.archivedSnapshots = new ArchivedSnapshots(
+                new ClosestSnapshot("200",
+                    true,
+                    "http://localhost:8080/web/20230614220926/archives/2021/03",
+                    "20230614220926")
+            );
+            return this;
+        }
+
         public ArchivedPageInfoBuilder timestamp(String timestamp) {
             this.timestamp = timestamp;
             return this;

--- a/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
@@ -53,8 +53,8 @@ public class ArchivedPageInfo {
             return this;
         }
 
-        public ArchivedPageInfoBuilder archivedSnapshots(ArchivedSnapshots archivedSnapshots) {
-            this.archivedSnapshots = archivedSnapshots;
+        public ArchivedPageInfoBuilder withEmptyArchivedSnapshots() {
+            this.archivedSnapshots = null;
             return this;
         }
 

--- a/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
@@ -39,6 +39,35 @@ public class ArchivedPageInfo {
         return archivedSnapshots.getSnapshot().getUrl();
     }
 
+    public static class ArchivedPageInfoBuilder {
+        private String url;
+        private ArchivedSnapshots archivedSnapshots;
+        private String timestamp;
+
+        public static ArchivedPageInfoBuilder builder() {
+            return new ArchivedPageInfoBuilder();
+        }
+
+        public ArchivedPageInfoBuilder url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public ArchivedPageInfoBuilder archivedSnapshots(ArchivedSnapshots archivedSnapshots) {
+            this.archivedSnapshots = archivedSnapshots;
+            return this;
+        }
+
+        public ArchivedPageInfoBuilder timestamp(String timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public ArchivedPageInfo build() {
+            return new ArchivedPageInfo(url, archivedSnapshots, timestamp);
+        }
+    }
+
     private static class ArchivedSnapshots {
 
         @JsonProperty("closest")

--- a/src/main/java/org/gsh/genidxpage/service/dto/CheckPostArchivedDto.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/CheckPostArchivedDto.java
@@ -2,13 +2,25 @@ package org.gsh.genidxpage.service.dto;
 
 public class CheckPostArchivedDto {
 
+    private final String year;
+    private final String month;
     private final String url;
     private final String timestamp;
 
     public CheckPostArchivedDto(String year, String month) {
+        this.year = year;
+        this.month = month;
         this.url = "agile.egloos.com/archives/" + year + "/" + String.format("%02d",
             Integer.parseInt(month));
         this.timestamp = "20240101";
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public String getMonth() {
+        return month;
     }
 
     public String getUrl() {

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -1,7 +1,6 @@
 package org.gsh.genidxpage.web;
 
 import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.http.HttpStatus;
@@ -15,10 +14,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller
 public class ArchivePageController {
 
-    private final WebArchiveApiCaller webArchiveApiCaller;
+    private final ArchivePageService service;
 
-    public ArchivePageController(final WebArchiveApiCaller webArchiveApiCaller) {
-        this.webArchiveApiCaller = webArchiveApiCaller;
+    public ArchivePageController(final ArchivePageService service) {
+        this.service = service;
     }
 
     @GetMapping("/post-links/{year}/{month}")
@@ -27,7 +26,6 @@ public class ArchivePageController {
         @PathVariable(value = "month") String month
     ) {
         CheckPostArchivedDto dto = new CheckPostArchivedDto(year, month);
-        ArchivePageService service = new ArchivePageService(webArchiveApiCaller);
         ArchivedPageInfo archivedPageInfo = service.findArchivedPageInfo(dto);
 
         String blogPost = service.findBlogPostPage(archivedPageInfo);

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -6,6 +6,7 @@ import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.response.PostLinkInfo;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,15 +34,13 @@ public class ArchivePageController {
         ArchivePageService service = new ArchivePageService(webArchiveApiCaller);
         ArchivedPageInfo archivedPageInfo = service.findArchivedPageInfo(dto);
 
-        ResponseEntity<String> blogPostResponse = webArchiveApiCaller.findBlogPostPage(
-            archivedPageInfo);
-        String blogPost = blogPostResponse.getBody();
+        String blogPost = service.findBlogPostPage(archivedPageInfo);
 
         WebPageParser webPageParser = new WebPageParser();
         List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
         String pageLinks = webPageParser.buildPageLinks(postLinks);
 
-        return ResponseEntity.status(blogPostResponse.getStatusCode())
+        return ResponseEntity.status(HttpStatus.OK)
             .body(pageLinks);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -1,11 +1,12 @@
 package org.gsh.genidxpage.web;
 
+import org.gsh.genidxpage.common.exception.ErrorCode;
+import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.response.PostLinkInfo;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,8 +34,7 @@ public class ArchivePageController {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
 
         if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body("resource not found");
+            throw new ArchivedPageNotFoundExceptioin(ErrorCode.BAD_REQUEST, "resource not found");
         }
 
         ResponseEntity<String> blogPostResponse = webArchiveApiCaller.findBlogPostPage(

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -1,7 +1,6 @@
 package org.gsh.genidxpage.web;
 
-import org.gsh.genidxpage.common.exception.ErrorCode;
-import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
+import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
@@ -31,11 +30,8 @@ public class ArchivePageController {
         @PathVariable(value = "month") String month
     ) {
         CheckPostArchivedDto dto = new CheckPostArchivedDto(year, month);
-        ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
-
-        if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
-            throw new ArchivedPageNotFoundExceptioin(ErrorCode.BAD_REQUEST, "resource not found");
-        }
+        ArchivePageService service = new ArchivePageService(webArchiveApiCaller);
+        ArchivedPageInfo archivedPageInfo = service.findArchivedPageInfo(dto);
 
         ResponseEntity<String> blogPostResponse = webArchiveApiCaller.findBlogPostPage(
             archivedPageInfo);

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -2,18 +2,14 @@ package org.gsh.genidxpage.web;
 
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
-import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
-import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import java.util.List;
 
 @ResponseBody
 @Controller
@@ -36,9 +32,7 @@ public class ArchivePageController {
 
         String blogPost = service.findBlogPostPage(archivedPageInfo);
 
-        WebPageParser webPageParser = new WebPageParser();
-        List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
-        String pageLinks = webPageParser.buildPageLinks(postLinks);
+        String pageLinks = service.buildPageLinks(blogPost);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(pageLinks);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,23 @@
 spring:
   application:
     name: genidxpage
+  datasource:
+    url: jdbc:mysql://localhost:3306/genidxpage?characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+  sql:
+    init:
+      platform: mysql
+      mode: always
+      schema-locations: classpath:sql/schema.sql
+      data-locations: classpath:sql/data.sql
+
+mybatis:
+  mapper-locations: classpath:mapper/*Mapper.xml
+  configuration:
+    map-underscore-to-camel-case: true
+
 webArchive:
   rootUri: x
   checkArchivedUri: /wayback/available?url={url}&timestamp={timestamp}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,8 +16,19 @@ spring:
 mybatis:
   mapper-locations: classpath:mapper/*Mapper.xml
   configuration:
+    log-impl: org.apache.ibatis.logging.slf4j.Slf4jImpl
     map-underscore-to-camel-case: true
 
 webArchive:
   rootUri: x
   checkArchivedUri: /wayback/available?url={url}&timestamp={timestamp}
+
+logging:
+  file:
+    name: log/app.log
+  level:
+    root: INFO
+    org.mybatis: DEBUG
+    com.mysql.cj.jdbc: DEBUG
+  pattern:
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %clr(%-5level) %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"

--- a/src/main/resources/mapper/WebArchiveReportMapper.xml
+++ b/src/main/resources/mapper/WebArchiveReportMapper.xml
@@ -12,7 +12,7 @@
                           created_at)
     VALUES (#{year},
             #{month},
-            #{pageExists}
+            #{pageExists},
             #{createdAt})
   </insert>
 </mapper>

--- a/src/main/resources/mapper/WebArchiveReportMapper.xml
+++ b/src/main/resources/mapper/WebArchiveReportMapper.xml
@@ -15,4 +15,15 @@
             #{pageExists},
             #{createdAt})
   </insert>
+
+  <select id="selectReportByYearMonth" resultType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+    SELECT id,
+           `year`,
+           `month`,
+           page_exists
+    FROM page_url_report
+    WHERE `year` = #{year}
+      AND `month` = #{month}
+      AND deleted_at = null
+  </select>
 </mapper>

--- a/src/main/resources/mapper/WebArchiveReportMapper.xml
+++ b/src/main/resources/mapper/WebArchiveReportMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.gsh.genidxpage.dao.WebArchiveReportMapper">
+  <insert id="insertReport" useGeneratedKeys="true" keyProperty="id"
+    parameterType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+
+    INSERT INTO page_url_report (year,
+                          month,
+                          page_exists,
+                          created_at)
+    VALUES (#{year},
+            #{month},
+            #{pageExists}
+            #{createdAt})
+  </insert>
+</mapper>

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO page_url (`year_month`, url_fetch_success)
-VALUES ('202103', 'SUCCESS');
+INSERT INTO page_url_report (year, month, page_exists, created_at)
+VALUES ('2021', '03', true, '2025-04-21T20:32:02.673678');

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO page_url (`year_month`, url_fetch_success)
+VALUES ('202103', 'SUCCESS');

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,10 +1,11 @@
-DROP TABLE IF EXISTS page_url;
+DROP TABLE IF EXISTS page_url_report;
 
-CREATE TABLE `page_url`
+CREATE TABLE `page_url_report`
 (
     `id`                bigint PRIMARY KEY NOT NULL AUTO_INCREMENT,
-    `year_month`        varchar(255),
-    `url_fetch_success` varchar(255),
+    `year`              varchar(255),
+    `month`             varchar(255),
+    `page_exists`        bool,
     `created_at`        datetime,
     `updated_at`        datetime,
     `deleted_at`        datetime

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS page_url;
+
+CREATE TABLE `page_url`
+(
+    `id`                bigint PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    `year_month`        varchar(255),
+    `url_fetch_success` varchar(255),
+    `created_at`        datetime,
+    `updated_at`        datetime,
+    `deleted_at`        datetime
+);

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
+import org.gsh.genidxpage.dao.WebArchiveReportMapper;
 import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
 import org.gsh.genidxpage.service.ApiCallReporter;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.ArchivePageController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +26,8 @@ public class AcceptanceTest {
     private ArchivePageController archivePageController;
     @Autowired
     private ApiCallReporter reporter;
+    @Autowired
+    private WebArchiveReportMapper mapper;
 
     @BeforeEach
     public void setUp() {
@@ -117,10 +121,9 @@ public class AcceptanceTest {
         // 서버는 web archive server에 아카이브된 블로그 글을 요청한다
         archivePageController.getBlogPostLinks("2021", "3");
 
-        // db에 요청 실패를 기록한다
-        // 어떻게 하지? requestReporter를 목 객체로 만들어서?
-        // db를 실제로 바꿔서? db의 상태를 롤백하도록 하려면 어떻게 해야하지?
-        // 테스트할 때 쓰는 db를 구분해야 할까?
+        // 서버는 db에 요청 성공을 기록한다
+        Assertions.assertThat(reporter.hasArchivedPage(new CheckPostArchivedDto("2021", "03")))
+            .isTrue();
 
         fakeWebArchiveServer.stop();
     }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -1,7 +1,6 @@
 package org.gsh.genidxpage;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
@@ -13,12 +12,18 @@ import org.gsh.genidxpage.web.ArchivePageController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
+@SpringBootTest
 public class AcceptanceTest {
 
     private ArchivePageController archivePageController;
-    private final static ApiCallReporter EMPTY_REPORTER = mock(ApiCallReporter.class);
+    @Autowired
+    private ApiCallReporter reporter;
 
     @BeforeEach
     public void setUp() {
@@ -27,7 +32,7 @@ public class AcceptanceTest {
             "/wayback/available?url={url}&timestamp={timestamp}",
             CustomRestTemplateBuilder.get()
         );
-        ArchivePageService service = new ArchivePageService(apiCaller, EMPTY_REPORTER);
+        ArchivePageService service = new ArchivePageService(apiCaller, reporter);
 
         archivePageController = new ArchivePageController(service);
     }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -5,23 +5,33 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
 import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
+import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.web.ArchivePageController;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 
 public class AcceptanceTest {
 
+    private ArchivePageController archivePageController;
+
+    @BeforeEach
+    public void setUp() {
+        WebArchiveApiCaller apiCaller = new WebArchiveApiCaller(
+            "http://localhost:8080",
+            "/wayback/available?url={url}&timestamp={timestamp}",
+            CustomRestTemplateBuilder.get()
+        );
+        ArchivePageService service = new ArchivePageService(apiCaller);
+
+        archivePageController = new ArchivePageController(service);
+    }
+
     @DisplayName("요청 연월에 등록된 블로그 글이 web archive에 없으면, 리소스가 존재하지 않음을 응답으로 받는다")
     @Test
     public void receive_not_found_msg_when_send_request() {
-        ArchivePageController archivePageController = new ArchivePageController(
-            new WebArchiveApiCaller("http://localhost:8080",
-                "/wayback/available?url={url}&timestamp={timestamp}",
-                CustomRestTemplateBuilder.get())
-        );
-
         FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
         fakeWebArchiveServer.respondItHasNoArchivedPage();
@@ -43,12 +53,6 @@ public class AcceptanceTest {
     @DisplayName("요청 연월에 등록된 블로그 글이 web archive에 있으면, 해당 월에 올라온 블로그 글에 접근할 수 있는 링크 목록을 응답으로 받는다")
     @Test
     public void receive_post_link_list_when_send_valid_request() {
-        ArchivePageController archivePageController = new ArchivePageController(
-            new WebArchiveApiCaller("http://localhost:8080",
-                "/wayback/available?url={url}&timestamp={timestamp}",
-                CustomRestTemplateBuilder.get())
-        );
-
         FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
         fakeWebArchiveServer.respondItHasArchivedPage();
@@ -71,12 +75,6 @@ public class AcceptanceTest {
     @DisplayName("요청 연월에 등록된 블로그 글이 여러 개면, 해당 블로그 글에 접근할 수 있는 링크 목록을 응답으로 받는다")
     @Test
     public void receive_post_link_list_when_multiple_posts_exists() {
-        ArchivePageController archivePageController = new ArchivePageController(
-            new WebArchiveApiCaller("http://localhost:8080",
-                "/wayback/available?url={url}&timestamp={timestamp}",
-                CustomRestTemplateBuilder.get())
-        );
-
         FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
         fakeWebArchiveServer.respondItHasArchivedPage();
@@ -101,12 +99,6 @@ public class AcceptanceTest {
     @DisplayName("요청 처리 성공 여부를 DB에 기록한다")
     @Test
     public void write_request_result_to_db_when_send_request() {
-        ArchivePageController archivePageController = new ArchivePageController(
-            new WebArchiveApiCaller("http://localhost:8080",
-                "/wayback/available?url={url}&timestamp={timestamp}",
-                CustomRestTemplateBuilder.get())
-        );
-
         FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
         fakeWebArchiveServer.respondItHasArchivedPage();

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -1,10 +1,12 @@
 package org.gsh.genidxpage;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
 import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
+import org.gsh.genidxpage.service.ApiCallReporter;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.web.ArchivePageController;
@@ -16,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 public class AcceptanceTest {
 
     private ArchivePageController archivePageController;
+    private final static ApiCallReporter EMPTY_REPORTER = mock(ApiCallReporter.class);
 
     @BeforeEach
     public void setUp() {
@@ -24,7 +27,7 @@ public class AcceptanceTest {
             "/wayback/available?url={url}&timestamp={timestamp}",
             CustomRestTemplateBuilder.get()
         );
-        ArchivePageService service = new ArchivePageService(apiCaller);
+        ArchivePageService service = new ArchivePageService(apiCaller, EMPTY_REPORTER);
 
         archivePageController = new ArchivePageController(service);
     }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -93,4 +93,30 @@ public class AcceptanceTest {
 
         fakeWebArchiveServer.stop();
     }
+
+    @DisplayName("요청 처리 성공 여부를 DB에 기록한다")
+    @Test
+    public void write_request_result_to_db_when_send_request() {
+        ArchivePageController archivePageController = new ArchivePageController(
+            new WebArchiveApiCaller("http://localhost:8080",
+                "/wayback/available?url={url}&timestamp={timestamp}",
+                CustomRestTemplateBuilder.get())
+        );
+
+        FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
+
+        fakeWebArchiveServer.respondItHasNoArchivedPage();
+
+        fakeWebArchiveServer.start();
+
+        // 서버는 web archive server에 아카이브된 블로그 글을 요청한다
+        archivePageController.getBlogPostLinks("1999", "7");
+
+        // db에 요청 실패를 기록한다
+        // 어떻게 하지? requestReporter를 목 객체로 만들어서?
+        // db를 실제로 바꿔서? db의 상태를 롤백하도록 하려면 어떻게 해야하지?
+        // 테스트할 때 쓰는 db를 구분해야 할까?
+
+        fakeWebArchiveServer.stop();
+    }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
@@ -1,0 +1,34 @@
+package org.gsh.genidxpage.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.api.Assertions;
+import org.gsh.genidxpage.dao.WebArchiveReportMapper;
+import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+class ApiCallReporterTest {
+
+    @DisplayName("web archive로부터 url을 받아온 연월인지 확인할 수 있다")
+    @Test
+    public void check_url_exists_in_web_archive_for_given_year_month() {
+        WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
+        ApiCallReporter reporter = new ApiCallReporter(mapper);
+        ArchivedPageUrlReport report = new ArchivedPageUrlReport(
+            "2021", "3", Boolean.TRUE, LocalDateTime.now()
+        );
+
+        when(mapper.selectReportByYearMonth("2021", "3")).thenReturn(report);
+
+        boolean hasArchivedPage = reporter.hasArchivedPage(
+            new CheckPostArchivedDto("2021", "3")
+        );
+        Assertions.assertThat(hasArchivedPage).isTrue();
+    }
+
+}

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -36,6 +36,6 @@ class ArchivePageServiceTest {
         Assertions.assertThrows(ArchivedPageNotFoundExceptioin.class,
             () -> service.findArchivedPageInfo(dto));
 
-        verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class));
+        verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class), any(Boolean.class));
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -1,6 +1,7 @@
 package org.gsh.genidxpage.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,5 +38,29 @@ class ArchivePageServiceTest {
             () -> service.findArchivedPageInfo(dto));
 
         verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class), any(Boolean.class));
+    }
+
+    @DisplayName("아키이빙된 페이지 정보를 찾았을 때 db에 기록한다")
+    @Test
+    public void write_to_db_when_archived_page_info_found() {
+        ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
+            .url("url")
+            .withAccessibleArchivedSnapshots()
+            .timestamp("20240101")
+            .build();
+        CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
+
+        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
+        when(caller.findArchivedPageInfo(any())).thenReturn(
+            archivedPageInfo
+        );
+        when(caller.isArchived(any())).thenReturn(true);
+        ApiCallReporter reporter = mock(ApiCallReporter.class);
+
+        ArchivePageService service = new ArchivePageService(caller, reporter);
+
+        service.findArchivedPageInfo(dto);
+
+        verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class), eq(Boolean.TRUE));
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -1,0 +1,41 @@
+package org.gsh.genidxpage.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
+import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
+import org.gsh.genidxpage.service.dto.ArchivedPageInfo.ArchivedPageInfoBuilder;
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ArchivePageServiceTest {
+
+    @DisplayName("아키이빙된 페이지 정보를 찾지 못했을 때 db에 기록한다")
+    @Test
+    public void write_to_db_when_archived_page_info_not_found() {
+        ArchivedPageInfo noArchivedPageInfo = ArchivedPageInfoBuilder.builder()
+            .url("")
+            .archivedSnapshots(null)
+            .timestamp(null)
+            .build();
+        CheckPostArchivedDto dto = new CheckPostArchivedDto("1999", "7");
+
+        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
+        when(caller.findArchivedPageInfo(any())).thenReturn(
+            noArchivedPageInfo
+        );
+        ApiCallReporter reporter = mock(ApiCallReporter.class);
+
+        ArchivePageService service = new ArchivePageService(caller, reporter);
+
+        Assertions.assertThrows(ArchivedPageNotFoundExceptioin.class,
+            () -> service.findArchivedPageInfo(dto));
+
+        verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class));
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -21,7 +21,7 @@ class ArchivePageServiceTest {
     public void write_to_db_when_archived_page_info_not_found() {
         ArchivedPageInfo noArchivedPageInfo = ArchivedPageInfoBuilder.builder()
             .url("")
-            .archivedSnapshots(null)
+            .withEmptyArchivedSnapshots()
             .timestamp(null)
             .build();
         CheckPostArchivedDto dto = new CheckPostArchivedDto("1999", "7");


### PR DESCRIPTION
- 컨트롤러에 몰려있는 서비스 로직을 서비스 레이어로 옮겼다
- 예외 처리기를 추가해서 서비스 로직 실행 중 예외 상황을 처리하도록 했다.
예외 발생 시 (서비스 로직의 반환 타입과 다른) ResponseEntity 타입 값을 반환해야 한다. 예외 처리기에서 이 값을 반환해준다.

- web archive 서버에 아카이빙된 페이지가 있는지 확인하는 요청 결과를 db에 기록한다.
  - 서버에 로컬 db를 연결한다
  - 요청한 연월에 대한 성공/실패 여부를 db에 기록한다

- 테스트용 빌더, 내부 클래스 등으로 ArchviedPageInfo 클래스가 비대해졌다. 정리할 예정
- web archive에 요청할 때 연월 중 월에 해당하는 값이 한 자리일 경우 0을 앞에 붙인다.
현재 db에는 0이 붙은 값이 그대로 들어가고, 그래서 db에 질의할 때도 동일하게 처리해줘야 한다.
이로 인해 로직 구현이 복잡해져서 정리가 필요하다