### PR TITLE
테스트 코드를 정리한다

### DIFF
--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -3,6 +3,7 @@ package org.gsh.genidxpage;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
@@ -27,8 +28,8 @@ public class FakeWebArchiveServer {
     public void respondBlogPostListInGivenYearMonth(String year, String month,
         boolean hasManyPost) {
         instance.stubFor(get(urlPathTemplate("/web/20230614220926/archives/{year}/{month}"))
-            .withPathParam("year", equalTo(year))
-            .withPathParam("month", equalTo(String.format("%02d", Integer.parseInt(month))))
+            .withPathParam("year", matching("[12][0-9]{3}"))
+            .withPathParam("month", matching("[01][0-9]"))
             .willReturn(aResponse().withStatus(200)
                 .withBody(
                     buildPostListPage(year, month, hasManyPost)
@@ -88,7 +89,7 @@ public class FakeWebArchiveServer {
 
     public void respondItHasArchivedPageFor(String year, String month) {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
-            .withQueryParam("url", equalTo(String.format("agile.egloos.com/archives/%s/%s", year, month)))
+            .withQueryParam("url", matching("agile.egloos.com/archives/[12][0-9]{3}/[01][0-9]"))
             .withQueryParam("timestamp", equalTo("20240101"))
             .willReturn(aResponse().withStatus(200).withBody(
                     String.format("""
@@ -116,7 +117,7 @@ public class FakeWebArchiveServer {
 
     public void respondItHasNoArchivedPage() {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
-            .withQueryParam("url", equalTo("agile.egloos.com/archives/1999/07"))
+            .withQueryParam("url", matching("agile.egloos.com/archives/[12][0-9]{3}/[0-9]{2}"))
             .withQueryParam("timestamp", equalTo("20240101"))
             .willReturn(aResponse().withStatus(200).withBody(
                     """

--- a/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
@@ -1,5 +1,6 @@
 package org.gsh.genidxpage.service;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,12 +24,11 @@ class ApiCallReporterTest {
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
         );
 
-        when(mapper.selectReportByYearMonth("2021", "3")).thenReturn(report);
+        when(mapper.selectReportByYearMonth(any(), any())).thenReturn(report);
 
         boolean hasArchivedPage = reporter.hasArchivedPage(
             new CheckPostArchivedDto("2021", "3")
         );
         Assertions.assertThat(hasArchivedPage).isTrue();
     }
-
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test;
 
 class ArchivePageServiceTest {
 
-    @DisplayName("아키이빙된 페이지 정보를 찾지 못했을 때 db에 기록한다")
+    @DisplayName("페이지 아키이빙 정보를 찾지 못했을 때 db에 기록한다")
     @Test
-    public void write_to_db_when_archived_page_info_not_found() {
+    public void write_to_db_when_page_archive_info_not_found() {
         ArchivedPageInfo noArchivedPageInfo = ArchivedPageInfoBuilder.builder()
             .url("")
             .withEmptyArchivedSnapshots()
@@ -37,12 +37,12 @@ class ArchivePageServiceTest {
         Assertions.assertThrows(ArchivedPageNotFoundExceptioin.class,
             () -> service.findArchivedPageInfo(dto));
 
-        verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class), any(Boolean.class));
+        verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class), eq(Boolean.FALSE));
     }
 
-    @DisplayName("아키이빙된 페이지 정보를 찾았을 때 db에 기록한다")
+    @DisplayName("페이지 아키이빙 정보를 찾았을 때 db에 기록한다")
     @Test
-    public void write_to_db_when_archived_page_info_found() {
+    public void write_to_db_when_page_archive_info_found() {
         ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
             .url("url")
             .withAccessibleArchivedSnapshots()

--- a/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
@@ -1,13 +1,12 @@
 package org.gsh.genidxpage.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.FakeWebArchiveServer;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
+import org.gsh.genidxpage.service.dto.ArchivedPageInfoBuilder;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,12 +28,14 @@ class WebArchiveApiCallerTest {
         CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
         ArchivedPageInfo archivedPageInfo = caller.findArchivedPageInfo(dto);
 
-        assertThat(archivedPageInfo.accessibleUrl().contains("2021/03")).isTrue();
+        // 페이지가 아카이빙되어 있는 경우
+        assertThat(caller.isArchived(archivedPageInfo)).isTrue();
 
         fakeWebArchiveServer.respondItHasNoArchivedPage();
         CheckPostArchivedDto dto2 = new CheckPostArchivedDto("1999", "7");
         ArchivedPageInfo noArchivedPageInfo = caller.findArchivedPageInfo(dto2);
 
+        // 페이지가 아카이빙되어 있지 않은 경우
         assertThat(caller.isArchived(noArchivedPageInfo)).isFalse();
 
         fakeWebArchiveServer.stop();

--- a/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
@@ -47,15 +47,17 @@ class WebArchiveApiCallerTest {
         WebArchiveApiCaller caller = new WebArchiveApiCaller("http://localhost:8080",
             "/wayback/available?url={url}&timestamp={timestamp}",
             CustomRestTemplateBuilder.get());
-        ArchivedPageInfo mockedPageInfo = mock(ArchivedPageInfo.class);
-        when(mockedPageInfo.isAccessible()).thenReturn(true);
+        ArchivedPageInfo pageInfo = ArchivedPageInfoBuilder.builder()
+            .withAccessibleArchivedSnapshots()
+            .build();
 
-        assertThat(caller.isArchived(mockedPageInfo)).isTrue();
+        assertThat(caller.isArchived(pageInfo)).isTrue();
 
-        ArchivedPageInfo mockedNoPageInfo = mock(ArchivedPageInfo.class);
-        when(mockedNoPageInfo.isAccessible()).thenReturn(false);
+        ArchivedPageInfo noPageInfo = ArchivedPageInfoBuilder.builder()
+            .withEmptyArchivedSnapshots()
+            .build();
 
-        assertThat(caller.isArchived(mockedNoPageInfo)).isFalse();
+        assertThat(caller.isArchived(noPageInfo)).isFalse();
     }
 
     @DisplayName("web archive 응답 json 데이터를 ArchivedPageInfo 타입 객체로 역직렬화할 수 있다")

--- a/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebPageParserTest.java
@@ -23,9 +23,9 @@ public class WebPageParserTest {
         PostLinkInfo postLink = webPageParser.findPostLinks(fileContent).get(0);
 
         Assertions.assertThat(postLink.getPageTitle())
-            .isEqualTo("올해 첫 AC2 과정 40기가 곧 열립니다");
+            .isNotNull();
         Assertions.assertThat(postLink.getPageUrl())
-            .isEqualTo("/web/20230614220926/http://agile.egloos.com/5946833");
+            .isNotNull();
     }
 
     @DisplayName("태그 규칙에 맞는 하나 이상의 html 요소를 검색할 수 있다")
@@ -51,16 +51,15 @@ public class WebPageParserTest {
         Path path = Paths.get("src/test/resources/2021-03-full-response.html");
         String fileContent = Files.readString(path, StandardCharsets.UTF_8);
         List<PostLinkInfo> postLinks = webPageParser.findPostLinks(fileContent);
-        Assertions.assertThat(webPageParser.buildPageLinks(postLinks)).isEqualTo(
-            "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">올해 첫 AC2 과정 40기가 곧 열립니다</a>"
-        );
+        for (String postLink : webPageParser.buildPageLinks(postLinks).split("\n")) {
+            Assertions.assertThat(postLink).matches("<a href=\".*\">.*</a>");
+        }
 
         Path path2 = Paths.get("src/test/resources/2020-02-response.html");
         String fileContent2 = Files.readString(path2, StandardCharsets.UTF_8);
         List<PostLinkInfo> postLinks2 = webPageParser.findPostLinks(fileContent2);
-        Assertions.assertThat(webPageParser.buildPageLinks(postLinks2)).isEqualTo(
-            "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>\n"
-                + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
-        );
+        for (String postLink : webPageParser.buildPageLinks(postLinks2).split("\n")) {
+            Assertions.assertThat(postLink).matches("<a href=\".*\">.*</a>");
+        }
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/dto/ArchivedPageInfoBuilder.java
+++ b/src/test/java/org/gsh/genidxpage/service/dto/ArchivedPageInfoBuilder.java
@@ -15,7 +15,7 @@ public class ArchivedPageInfoBuilder {
     }
 
     public ArchivedPageInfoBuilder withEmptyArchivedSnapshots() {
-        this.archivedSnapshots = null;
+        this.archivedSnapshots = new ArchivedSnapshots();
         return this;
     }
 


### PR DESCRIPTION
#### 테스트 코드를 정리한다.

입력을 유연하게 받을 수 있게 만들어서, 입력값이 바뀌더라도 테스트를 항상 고쳐야할 필요 없게 한다
 - FakeWebArchiveServer, 테스트 단정문에 적용

mock 대신 builder로 ArchivedPageInfo 객체를 만든다
 - WebArchiveApiCallerTest에서 ArchivedPageInfo 객체를 빌더로 생성하도록 바꾼다
 - ArchivedPageInfoBuilder.withEmptyArchivedSnapshots() 구현을 고친다.
 아카이빙된 정보가 없을 경우에도 ArchivedPageInfo 내부 필드인 ArchivedSnapshots
 객체는 null이 아니라 초기화된 상태여야 했다.

이외 테스트명과 단정문을 다듬는다

