### PR TITLE
외부 서버로부터 얻은 응답으로 인덱스 파일을 생성할 수 있다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -38,18 +38,18 @@ public class IndexPageGenerator {
 
     String generateHeader() {
         return """
-  <html>
-    <head>
-      <meta charset="utf-8">
-    </head>
-    <body>
-  """;
+            <html>
+              <head>
+                <meta charset="utf-8">
+              </head>
+              <body>
+            """;
     }
 
     String generateFooter() {
         return """
-                </body>
-              </html>
-              """;
+              </body>
+            </html>
+            """;
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -1,0 +1,18 @@
+package org.gsh.genidxpage.service;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+
+public class IndexPageGenerator {
+
+    private final String inputPath;
+
+    public IndexPageGenerator(@Value("${index-page.input-path}") final String inputPath) {
+        this.inputPath = inputPath;
+    }
+
+    public void generateIndexPage(List<String> pageLinksList) {
+
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -23,6 +23,7 @@ public class IndexPageGenerator {
             String[] split = pageLink.split("\n");
             for (String link : split) {
                 builder.append(link);
+                builder.append("<br>");
                 builder.append("\n");
             }
         }

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -2,17 +2,53 @@ package org.gsh.genidxpage.service;
 
 import org.springframework.beans.factory.annotation.Value;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 public class IndexPageGenerator {
 
     private final String inputPath;
 
-    public IndexPageGenerator(@Value("${index-page.input-path}") final String inputPath) {
+    public IndexPageGenerator(@Value("${index-page.path}") final String inputPath) {
         this.inputPath = inputPath;
     }
 
-    public void generateIndexPage(List<String> pageLinksList) {
+    public void generateIndexPage(List<String> pageLinksList) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        builder.append(generateHeader());
+        for (String pageLink : pageLinksList) {
+            String[] split = pageLink.split("\n");
+            for (String link : split) {
+                builder.append(link);
+                builder.append("\n");
+            }
+        }
+        builder.append(generateFooter());
 
+        Path dirPath = Path.of(inputPath);
+        Files.createDirectories(dirPath);
+
+        Path filePath = Path.of(inputPath + "/index.html");
+        Files.write(filePath, builder.toString().getBytes(), StandardOpenOption.CREATE);
+    }
+
+    String generateHeader() {
+        return """
+  <html>
+    <head>
+      <meta charset="utf-8">
+    </head>
+    <body>
+  """;
+    }
+
+    String generateFooter() {
+        return """
+                </body>
+              </html>
+              """;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,8 @@ webArchive:
 
 bulk-request:
   input-path: /src/main/resources/static/year-month-list
+index-page:
+  path: /app/static
 
 logging:
   file:

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -22,10 +22,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
-import wiremock.com.github.jknack.handlebars.internal.Files;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 @Transactional
@@ -211,12 +212,12 @@ public class AcceptanceTest {
             List<String> pageLinksList = bulkRequestSender.sendAll(yearMonths, service);
 
             IndexPageGenerator generator = new IndexPageGenerator(
-                "/src/test/resources/static/index.html"
+                "/tmp/genidxpage/test"
             );
             generator.generateIndexPage(pageLinksList);
 
             Assertions.assertThat(
-                Files.read("/src/test/resources/static/index.html", StandardCharsets.UTF_8)
+                Files.readString(Path.of("/tmp/genidxpage/test/index.html"), StandardCharsets.UTF_8)
             ).isNotNull();
 
             fakeWebArchiveServer.stop();

--- a/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
@@ -3,7 +3,6 @@ package org.gsh.genidxpage.service;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -11,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-@SpringBootTest
 class IndexPageGeneratorTest {
 
     @DisplayName("블로그 링크 목록으로 인덱스 페이지를 만들 수 있다")

--- a/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
@@ -1,0 +1,27 @@
+package org.gsh.genidxpage.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+@SpringBootTest
+class IndexPageGeneratorTest {
+
+    @DisplayName("블로그 링크 목록으로 인덱스 페이지를 만들 수 있다")
+    @Test
+    public void generate_index_page_from_blog_link_list() throws IOException {
+
+        List<String> pageLinksList = List.of("l1\nl2", "l3", "l4");
+        IndexPageGenerator generator = new IndexPageGenerator("/tmp/genidxpage");
+        generator.generateIndexPage(pageLinksList);
+        String fileContent = Files.readString(Path.of("/tmp/genidxpage/index.html"), StandardCharsets.UTF_8);
+        Assertions.assertThat(fileContent).contains("l1\nl2\nl3\nl4");
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
@@ -20,6 +20,9 @@ class IndexPageGeneratorTest {
         IndexPageGenerator generator = new IndexPageGenerator("/tmp/genidxpage");
         generator.generateIndexPage(pageLinksList);
         String fileContent = Files.readString(Path.of("/tmp/genidxpage/index.html"), StandardCharsets.UTF_8);
-        Assertions.assertThat(fileContent).contains("l1\nl2\nl3\nl4");
+        Assertions.assertThat(fileContent).contains("l1")
+            .contains("l2")
+            .contains("l3")
+            .contains("l4");
     }
 }


### PR DESCRIPTION
#### web archive 서버에 여러 번 요청한 결과를 모아서 인덱스 페이지를 생성한다

 - 리소스 경로가 아닌 파일 시스템 상의 다른 경로에 인덱스 파일을
   생성한다
 - 애플리케이션 실행 시 파일을 리소스 경로에 생성하면, src/가 아닌
   build/ 하위 경로에 파일이 생성된다. 그러면 애플리케이션 중지 및
   재시작 시 이전에 수정된 파일이 지워질 수 있다.
 - 따라서 테스트에선 임시 디렉토리인 /tmp 하위에 파일을 만들어
   테스트하고, 운영 환경은 앱 설치 위치 이외의 디렉토리에 파일을
   만들도록 한다(app.yaml의 index-page.path에 설정)
