### PR TITLE
외부 서버 요청 처리 오류를 해결한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/config/CustomRestTemplateBuilder.java
+++ b/src/main/java/org/gsh/genidxpage/config/CustomRestTemplateBuilder.java
@@ -12,6 +12,11 @@ public class CustomRestTemplateBuilder {
     @Bean
     public static RestTemplateBuilder get() {
         return new RestTemplateBuilder()
+            .defaultHeader("User-Agent",
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+                "AppleWebKit/537.36 (KHTML, like Gecko)",
+                "Chrome/134.0.0.0",
+                "Safari/537.36")
             .readTimeout(Duration.ofSeconds(15L))
             .connectTimeout(Duration.ofSeconds(15L))
             .errorHandler(new CustomRestTemplateErrorHandler());

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -7,7 +7,6 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,13 +29,15 @@ public class WebArchiveApiCaller {
     }
 
     public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
-        String checkArchivedUrl = "/wayback/available";
-        UriComponents uri = UriComponentsBuilder.fromUriString(rootUri + checkArchivedUrl)
-            .queryParam("url", dto.getUrl())
-            .queryParam("timestamp", dto.getTimestamp())
-            .build();
+        String uri = UriComponentsBuilder.fromUriString(rootUri)
+            .uriComponents(
+                UriComponentsBuilder.fromUriString(checkArchivedUri)
+                    .buildAndExpand(dto.getUrl(), dto.getTimestamp())
+            )
+            .build().toUriString();
+
         ResponseEntity<String> archivedPageInfo = restTemplate.getForEntity(
-            uri.toUriString(),
+            uri,
             String.class
         );
 

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -7,6 +7,8 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -15,6 +17,7 @@ public class WebArchiveApiCaller {
 
     private final RestTemplate restTemplate;
     private final String checkArchivedUri;
+    private String rootUri;
 
     public WebArchiveApiCaller(
         @Value("${webArchive.rootUri}") final String rootUri,
@@ -23,14 +26,18 @@ public class WebArchiveApiCaller {
     ) {
         this.restTemplate = restTemplateBuilder.rootUri(rootUri).build();
         this.checkArchivedUri = checkArchivedUri;
+        this.rootUri = rootUri;
     }
 
     public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
+        String checkArchivedUrl = "/wayback/available";
+        UriComponents uri = UriComponentsBuilder.fromUriString(rootUri + checkArchivedUrl)
+            .queryParam("url", dto.getUrl())
+            .queryParam("timestamp", dto.getTimestamp())
+            .build();
         ResponseEntity<String> archivedPageInfo = restTemplate.getForEntity(
-            checkArchivedUri,
-            String.class,
-            dto.getUrl(),
-            dto.getTimestamp()
+            uri.toUriString(),
+            String.class
         );
 
         String response = archivedPageInfo.getBody();

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -16,14 +16,14 @@ public class WebArchiveApiCaller {
 
     private final RestTemplate restTemplate;
     private final String checkArchivedUri;
-    private String rootUri;
+    private final String rootUri;
 
     public WebArchiveApiCaller(
         @Value("${webArchive.rootUri}") final String rootUri,
         @Value("${webArchive.checkArchivedUri}") String checkArchivedUri,
         RestTemplateBuilder restTemplateBuilder
     ) {
-        this.restTemplate = restTemplateBuilder.rootUri(rootUri).build();
+        this.restTemplate = restTemplateBuilder.build();
         this.checkArchivedUri = checkArchivedUri;
         this.rootUri = rootUri;
     }

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -29,12 +29,7 @@ public class WebArchiveApiCaller {
     }
 
     public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
-        String uri = UriComponentsBuilder.fromUriString(rootUri)
-            .uriComponents(
-                UriComponentsBuilder.fromUriString(checkArchivedUri)
-                    .buildAndExpand(dto.getUrl(), dto.getTimestamp())
-            )
-            .build().toUriString();
+        String uri = buildUri(dto);
 
         ResponseEntity<String> archivedPageInfo = restTemplate.getForEntity(
             uri,
@@ -48,6 +43,15 @@ public class WebArchiveApiCaller {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    String buildUri(final CheckPostArchivedDto dto) {
+        return UriComponentsBuilder.fromUriString(rootUri)
+            .uriComponents(
+                UriComponentsBuilder.fromUriString(checkArchivedUri)
+                    .buildAndExpand(dto.getUrl(), dto.getTimestamp())
+            )
+            .build().toUriString();
     }
 
     public boolean isArchived(final ArchivedPageInfo archivedPageInfo) {

--- a/src/main/java/org/gsh/genidxpage/service/dto/CheckPostArchivedDto.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/CheckPostArchivedDto.java
@@ -10,9 +10,9 @@ public class CheckPostArchivedDto {
     public CheckPostArchivedDto(String year, String month) {
         this.year = year;
         this.month = month;
-        this.url = "agile.egloos.com/archives/" + year + "/" + String.format("%02d",
+        this.url = "https://agile.egloos.com/archives/" + year + "/" + String.format("%02d",
             Integer.parseInt(month));
-        this.timestamp = "20240101";
+        this.timestamp = "20230401";
     }
 
     public String getYear() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ mybatis:
 
 webArchive:
   rootUri: https://archive.org
-  checkArchivedUri: /wayback/available?url={url}
+  checkArchivedUri: /wayback/available?url={url}&timestamp={timestamp}
 
 bulk-request:
   input-path: /src/main/resources/static/year-month-list

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,8 @@ mybatis:
     map-underscore-to-camel-case: true
 
 webArchive:
-  rootUri: x
-  checkArchivedUri: /wayback/available?url={url}&timestamp={timestamp}
+  rootUri: https://archive.org
+  checkArchivedUri: /wayback/available?url={url}
 
 bulk-request:
   input-path: /src/main/resources/static/year-month-list
@@ -35,5 +35,6 @@ logging:
     root: INFO
     org.mybatis: DEBUG
     com.mysql.cj.jdbc: DEBUG
+    org.springframework.web.client.RestTemplate: DEBUG
   pattern:
     console: "%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %clr(%-5level) %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -1,7 +1,6 @@
 package org.gsh.genidxpage;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate;
@@ -89,8 +88,8 @@ public class FakeWebArchiveServer {
 
     public void respondItHasArchivedPageFor(String year, String month) {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
-            .withQueryParam("url", matching("agile.egloos.com/archives/[12][0-9]{3}/[01][0-9]"))
-            .withQueryParam("timestamp", equalTo("20240101"))
+            .withQueryParam("url", matching("http[s]?://agile.egloos.com/archives/[12][0-9]{3}/[01][0-9]"))
+            .withQueryParam("timestamp", matching("[0-9]{8}"))
             .willReturn(aResponse().withStatus(200).withBody(
                     String.format("""
                         {
@@ -117,8 +116,8 @@ public class FakeWebArchiveServer {
 
     public void respondItHasNoArchivedPage() {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
-            .withQueryParam("url", matching("agile.egloos.com/archives/[12][0-9]{3}/[0-9]{2}"))
-            .withQueryParam("timestamp", equalTo("20240101"))
+            .withQueryParam("url", matching("http[s]?://agile.egloos.com/archives/[12][0-9]{3}/[0-9]{2}"))
+            .withQueryParam("timestamp", matching("[0-9]{8}"))
             .willReturn(aResponse().withStatus(200).withBody(
                     """
                         {

--- a/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
@@ -10,6 +10,7 @@ import org.gsh.genidxpage.service.dto.ArchivedPageInfoBuilder;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.util.UriComponentsBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 class WebArchiveApiCallerTest {
@@ -76,5 +77,22 @@ class WebArchiveApiCallerTest {
             .isInstanceOf(ArchivedPageInfo.class);
 
         fakeWebArchiveServer.stop();
+    }
+
+    @DisplayName("url을 인코딩할 수 있다")
+    @Test
+    public void encode_simple_url() {
+        String rootUri = "http://archive.org";
+        String checkArchivedUri = "/wayback/available?url={url}&timestamp={timestamp}";
+        String uri = UriComponentsBuilder.fromUriString(rootUri)
+            .uriComponents(
+                UriComponentsBuilder.fromUriString(checkArchivedUri)
+                    .buildAndExpand("https://x", "20240101")
+            )
+            .build().toString();
+
+        Assertions.assertThat(uri).isEqualTo(
+            "http://archive.org/wayback/available?url=https://x&timestamp=20240101"
+        );
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
@@ -10,7 +10,6 @@ import org.gsh.genidxpage.service.dto.ArchivedPageInfoBuilder;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.util.UriComponentsBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 class WebArchiveApiCallerTest {
@@ -82,17 +81,13 @@ class WebArchiveApiCallerTest {
     @DisplayName("url을 인코딩할 수 있다")
     @Test
     public void encode_simple_url() {
-        String rootUri = "http://archive.org";
-        String checkArchivedUri = "/wayback/available?url={url}&timestamp={timestamp}";
-        String uri = UriComponentsBuilder.fromUriString(rootUri)
-            .uriComponents(
-                UriComponentsBuilder.fromUriString(checkArchivedUri)
-                    .buildAndExpand("https://x", "20240101")
-            )
-            .build().toString();
+        WebArchiveApiCaller caller = new WebArchiveApiCaller("http://localhost:8080",
+            "/wayback/available?url={url}&timestamp={timestamp}",
+            CustomRestTemplateBuilder.get());
 
-        Assertions.assertThat(uri).isEqualTo(
-            "http://archive.org/wayback/available?url=https://x&timestamp=20240101"
+        CheckPostArchivedDto dto = new CheckPostArchivedDto("2023", "1");
+        Assertions.assertThat(caller.buildUri(dto)).matches(
+            "http://localhost:8080/wayback/available\\?url=https://agile.egloos.com/archives/2023/01&timestamp=\\d{8}"
         );
     }
 }


### PR DESCRIPTION
#### 문제 상황
스프링 서버를 띄워서 GET post-links 요청을 보냈을 때 web archive에서 not found로 응답하는 오류가 발생

#### 문제 분석 과정
다음 방법으로 발생하는 상황을 확인했다
  - curl, postman, 웹 브라우저(+웹 콘솔)에서 요청을 보내서 요청 헤더 등 요청이 어떤 식으로 보내지는지 확인했다
  `curl -v -X GET http://archive.org/wayback/available?url=https://agile.egloos.com/archives/2021/03`
  - genidxpage 서버로 api 호출했을 때 요청이 어떤 식으로 보내지는지 로그를 통해 확인했다
 `curl -X GET --location "http://localhost:8080/post-links/2021/3"`

#### 문제 해결
 - user-agent 헤더, 쿼리 파라미터 인코딩 미적용 등을 원인으로 예상하고 고쳐보았지만 아니었다
 - "url" 쿼리 파라미터 값과 url 호스트명이 잘못 설정되어 있는 게 문제였고, 고쳐서 해결했다

#### 이외
- url 생성 로직과 관련 값을 정리하고, 변경으로 인해 깨지는 테스트를 고친다
