### PR TITLE
커밋 전에 mybatis xml 내 sql 문법 체크한다

### DIFF
--- a/hooks/check_sql.rb
+++ b/hooks/check_sql.rb
@@ -1,0 +1,57 @@
+require 'nokogiri'
+
+# 컬럼 타입에 따른 리터럴 값을 설정한다
+def dummy_value_for(mysql_type)
+  case mysql_type
+  when /int/, /bigint/ then "1"
+  when /bool/ then "true"
+  when /char/, /text/, /varchar/ then "'sample'"
+  when /date/, /time/ then "'2024-01-01 00:00:00'"
+  when /decimal/, /float/, /double/ then "1.23"
+  else "null"
+  end
+end
+
+# DB 테이블 스키마 파일로부터 컬럼별 필드를 알아낸다
+def fetch_column_types(schema_path, table_name)
+  schema = File.read(schema_path)
+
+  table_def = schema[/CREATE TABLE `#{table_name}`.*?\);/m]
+  return {} unless table_def
+
+  types = {}
+  table_def.scan(/\s*`?(\w+)`?\s+(\w+),?/) do |col, type|
+    types[col] = type
+  end
+  types
+end
+
+# XML에서 SQL 추출 후 리터럴을 대입한다
+def extract_and_substitute(xml_path, table_name)
+  doc = Nokogiri::XML(File.read(xml_path))
+  types = fetch_column_types("./src/main/resources/sql/schema.sql", table_name)
+
+  sqls = doc.xpath("//insert | //update | //select | //delete").map do |node|
+    raw_sql = node.text.strip
+
+    substituted_sql = raw_sql.gsub(/^(.*)(#\{(\w+)})(.*)$/) do
+      left = $1
+      camel_param = $3
+      right = $4
+      snake_param = camel_param.gsub(/(.)([A-Z])/,'\1_\2').downcase!
+
+      mysql_type = snake_param == "" ? types[camel_param] : types[snake_param]
+      sub = dummy_value_for(mysql_type || "varchar") # fallback
+      "#{left}#{sub}#{right}"
+    end
+    substituted_sql
+  end
+
+  sqls
+end
+
+sqls = extract_and_substitute("./src/main/resources/mapper/WebArchiveReportMapper.xml", "page_url_report")
+sqls.each_with_index do |sql, idx|
+  File.write("./hooks/.sql_check/sql_#{idx + 1}.sql", sql)
+  puts `sqlfluff lint ./hooks/.sql_check/sql_#{idx + 1}.sql --dialect mysql --rules PRS`
+end

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+added_path_list = `git diff-index --cached HEAD --name-only`
+added_path_list.split("\n").each do |added_path|
+  if added_path.split("/")[0...-1].join("/") == "src/main/resources/mapper"
+    sql_syntax_err = `ruby ./hooks/check_sql.rb`
+    if sql_syntax_err != ""
+      puts "current index includes invalid sql edit"
+      puts sql_syntax_err
+      exit 1
+    end
+  end
+end


### PR DESCRIPTION
- 현재 git index에 포함된 변경사항 중 mybatis xml이 있을 경우, sql 문법 체크한다. 에러가 날 경우, 커밋을 중단한다
- sql 문법 체크에는 sqlfluff를 쓴다. `--rules PRS`로 포맷 관련 에러는 무시한다
- 일반화 필요하다
  - WebArchiveReportMapper 이외 다른 xml도 감지해서 체크하도록
  - 여러 mapper 파일이 바뀔 경우에도 적용 가능하도록