### PR TITLE
일괄 요청 및 인덱스 생성을 스케쥴링한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/common/exception/ErrorCode.java
+++ b/src/main/java/org/gsh/genidxpage/common/exception/ErrorCode.java
@@ -2,7 +2,8 @@ package org.gsh.genidxpage.common.exception;
 
 public enum ErrorCode {
 
-    BAD_REQUEST("400", "잘못된 요청");
+    BAD_REQUEST("400", "잘못된 요청"),
+    SERVER_FAULT("500", "서버 오류");
 
     private final String code;
     private final String reason;

--- a/src/main/java/org/gsh/genidxpage/config/SchedulingConfiguration.java
+++ b/src/main/java/org/gsh/genidxpage/config/SchedulingConfiguration.java
@@ -1,0 +1,14 @@
+package org.gsh.genidxpage.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@ConditionalOnProperty(
+    value = "app.scheduling.enable", havingValue = "true", matchIfMissing = true
+)
+@EnableScheduling
+@Configuration
+public class SchedulingConfiguration {
+
+}

--- a/src/main/java/org/gsh/genidxpage/exception/FailToCreateDirectoryException.java
+++ b/src/main/java/org/gsh/genidxpage/exception/FailToCreateDirectoryException.java
@@ -1,0 +1,21 @@
+package org.gsh.genidxpage.exception;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+
+import java.io.IOException;
+
+public class FailToCreateDirectoryException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public FailToCreateDirectoryException(IOException e, ErrorCode errorCode, String message) {
+        super(errorCode.getReason(), e);
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/exception/FailToReadRequestInputFileException.java
+++ b/src/main/java/org/gsh/genidxpage/exception/FailToReadRequestInputFileException.java
@@ -1,0 +1,21 @@
+package org.gsh.genidxpage.exception;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+
+import java.io.IOException;
+
+public class FailToReadRequestInputFileException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public FailToReadRequestInputFileException(IOException e, ErrorCode errorCode, String message) {
+        super(errorCode.getReason(), e);
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/exception/FailToWriteFileException.java
+++ b/src/main/java/org/gsh/genidxpage/exception/FailToWriteFileException.java
@@ -1,0 +1,21 @@
+package org.gsh.genidxpage.exception;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+
+import java.io.IOException;
+
+public class FailToWriteFileException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public FailToWriteFileException(IOException e, ErrorCode errorCode, String message) {
+        super(errorCode.getReason(), e);
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -3,6 +3,7 @@ package org.gsh.genidxpage.scheduler;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.BulkRequestSender;
 import org.gsh.genidxpage.service.IndexPageGenerator;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -21,8 +22,10 @@ public class WebArchiveScheduler {
         this.indexPageGenerator = indexPageGenerator;
     }
 
+    @Scheduled(cron = "0 0 * * * *")
     public void scheduleSend() {
-        doSend();
+        List<String> pageLinkList = doSend();
+        doGenerate(pageLinkList);
     }
 
     public List<String> doSend() {

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -2,8 +2,10 @@ package org.gsh.genidxpage.scheduler;
 
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.BulkRequestSender;
+import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.util.List;
 
 @Component
@@ -11,21 +13,25 @@ public class WebArchiveScheduler {
 
     private final BulkRequestSender bulkRequestSender;
     private final ArchivePageService archivePageService;
+    private final IndexPageGenerator indexPageGenerator;
 
-    public WebArchiveScheduler(
-        BulkRequestSender bulkRequestSender,
-        ArchivePageService archivePageService
-    ) {
+    public WebArchiveScheduler(BulkRequestSender bulkRequestSender,
+        ArchivePageService archivePageService, IndexPageGenerator indexPageGenerator) {
         this.bulkRequestSender = bulkRequestSender;
         this.archivePageService = archivePageService;
+        this.indexPageGenerator = indexPageGenerator;
     }
 
     public void scheduleSend() {
         doSend();
     }
 
-    public void doSend() {
+    public List<String> doSend() {
         List<String> yearMonths = bulkRequestSender.prepareInput();
-        bulkRequestSender.sendAll(yearMonths, archivePageService);
+        return bulkRequestSender.sendAll(yearMonths, archivePageService);
+    }
+
+    void doGenerate(List<String> pageLinkList) throws IOException {
+        indexPageGenerator.generateIndexPage(pageLinkList);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -1,0 +1,8 @@
+package org.gsh.genidxpage.scheduler;
+
+public class WebArchiveScheduler {
+
+    public void doSend() {
+
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -5,7 +5,6 @@ import org.gsh.genidxpage.service.BulkRequestSender;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.List;
 
 @Component
@@ -31,7 +30,7 @@ public class WebArchiveScheduler {
         return bulkRequestSender.sendAll(yearMonths, archivePageService);
     }
 
-    void doGenerate(List<String> pageLinkList) throws IOException {
+    void doGenerate(List<String> pageLinkList) {
         indexPageGenerator.generateIndexPage(pageLinkList);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -1,8 +1,31 @@
 package org.gsh.genidxpage.scheduler;
 
+import org.gsh.genidxpage.service.ArchivePageService;
+import org.gsh.genidxpage.service.BulkRequestSender;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
 public class WebArchiveScheduler {
 
-    public void doSend() {
+    private final BulkRequestSender bulkRequestSender;
+    private final ArchivePageService archivePageService;
 
+    public WebArchiveScheduler(
+        BulkRequestSender bulkRequestSender,
+        ArchivePageService archivePageService
+    ) {
+        this.bulkRequestSender = bulkRequestSender;
+        this.archivePageService = archivePageService;
+    }
+
+    public void scheduleSend() {
+        doSend();
+    }
+
+    public void doSend() {
+        List<String> yearMonths = bulkRequestSender.prepareInput();
+        bulkRequestSender.sendAll(yearMonths, archivePageService);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -1,9 +1,8 @@
 package org.gsh.genidxpage.service;
 
-import org.gsh.genidxpage.common.exception.ErrorCode;
-import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.gsh.genidxpage.service.dto.EmptyArchivedPageInfo;
 import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -23,6 +22,9 @@ public class AgileStoryArchivePageService implements ArchivePageService {
 
     public String findBlogPageLink(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = this.findArchivedPageInfo(dto);
+        if (archivedPageInfo.isEmpty()) {
+            return "";
+        }
         String blogPost = this.findBlogPostPage(archivedPageInfo);
         return this.buildPageLinks(blogPost);
     }
@@ -32,7 +34,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
 
         if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
             reporter.reportArchivedPageSearch(dto, Boolean.FALSE);
-            throw new ArchivedPageNotFoundExceptioin(ErrorCode.BAD_REQUEST, "resource not found");
+            return new EmptyArchivedPageInfo();
         }
 
         reporter.reportArchivedPageSearch(dto, Boolean.TRUE);

--- a/src/main/java/org/gsh/genidxpage/service/BulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/service/BulkRequestSender.java
@@ -1,5 +1,7 @@
 package org.gsh.genidxpage.service;
 
+import org.gsh.genidxpage.common.exception.ErrorCode;
+import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -22,9 +24,14 @@ public class BulkRequestSender {
         this.inputPath = inputPath;
     }
 
-    public List<String> prepareInput() throws IOException {
+    public List<String> prepareInput() {
         Path path = Paths.get(this.inputPath);
-        String fileContent = Files.readString(path, StandardCharsets.UTF_8);
+        String fileContent = "";
+        try {
+            fileContent = Files.readString(path, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FailToReadRequestInputFileException(e, ErrorCode.SERVER_FAULT, "fail to read request input file");
+        }
         List<String> yearMonths = Arrays.stream(fileContent.strip().split("\n"))
             .collect(ArrayList::new, List::add, List::addAll);
         return yearMonths;

--- a/src/main/java/org/gsh/genidxpage/service/BulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/service/BulkRequestSender.java
@@ -4,6 +4,7 @@ import org.gsh.genidxpage.common.exception.ErrorCode;
 import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -25,13 +26,16 @@ public class BulkRequestSender {
     }
 
     public List<String> prepareInput() {
-        Path path = Paths.get(this.inputPath);
+        ClassPathResource classPathResource = new ClassPathResource(inputPath);
         String fileContent = "";
+
         try {
+            Path  path = Paths.get(classPathResource.getURI());
             fileContent = Files.readString(path, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new FailToReadRequestInputFileException(e, ErrorCode.SERVER_FAULT, "fail to read request input file");
         }
+
         List<String> yearMonths = Arrays.stream(fileContent.strip().split("\n"))
             .collect(ArrayList::new, List::add, List::addAll);
         return yearMonths;

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -1,6 +1,7 @@
 package org.gsh.genidxpage.service;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -8,6 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 
+@Component
 public class IndexPageGenerator {
 
     private final String inputPath;

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -1,5 +1,8 @@
 package org.gsh.genidxpage.service;
 
+import org.gsh.genidxpage.common.exception.ErrorCode;
+import org.gsh.genidxpage.exception.FailToCreateDirectoryException;
+import org.gsh.genidxpage.exception.FailToWriteFileException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -18,7 +21,10 @@ public class IndexPageGenerator {
         this.inputPath = inputPath;
     }
 
-    public void generateIndexPage(List<String> pageLinksList) throws IOException {
+    // TODO
+    //  파일 관련 연산을 별도의 객체로 분리
+    //  예외 발생 상황 테스트를 추가
+    public void generateIndexPage(List<String> pageLinksList) {
         StringBuilder builder = new StringBuilder();
         builder.append(generateHeader());
         for (String pageLink : pageLinksList) {
@@ -32,10 +38,20 @@ public class IndexPageGenerator {
         builder.append(generateFooter());
 
         Path dirPath = Path.of(inputPath);
-        Files.createDirectories(dirPath);
+        try {
+            Files.createDirectories(dirPath);
+        } catch (IOException e) {
+            throw new FailToCreateDirectoryException(e, ErrorCode.SERVER_FAULT,
+                "fail to create directory to store index file");
+        }
 
         Path filePath = Path.of(inputPath + "/index.html");
-        Files.write(filePath, builder.toString().getBytes(), StandardOpenOption.CREATE);
+        try {
+            Files.write(filePath, builder.toString().getBytes(), StandardOpenOption.CREATE);
+        } catch (IOException e) {
+            throw new FailToWriteFileException(e, ErrorCode.SERVER_FAULT,
+                "fail to write index file");
+        }
     }
 
     String generateHeader() {

--- a/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/ArchivedPageInfo.java
@@ -38,4 +38,8 @@ public class ArchivedPageInfo {
     public String accessibleUrl() {
         return archivedSnapshots.getSnapshot().getUrl();
     }
+
+    public boolean isEmpty() {
+        return false;
+    }
 }

--- a/src/main/java/org/gsh/genidxpage/service/dto/EmptyArchivedPageInfo.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/EmptyArchivedPageInfo.java
@@ -1,0 +1,8 @@
+package org.gsh.genidxpage.service.dto;
+
+public class EmptyArchivedPageInfo extends ArchivedPageInfo {
+
+    public boolean isEmpty() {
+        return true;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ webArchive:
   checkArchivedUri: /wayback/available?url={url}&timestamp={timestamp}
 
 bulk-request:
-  input-path: /src/main/resources/static/year-month-list
+  input-path: static/year-month-list
 index-page:
   path: /app/static
 

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -151,7 +151,7 @@ public class AcceptanceTest {
     class ArchivePageSchedulingTest {
         @BeforeEach
         public void setUp() {
-            bulkRequestSender = new BulkRequestSender("src/test/resources/static/year-month-list");
+            bulkRequestSender = new BulkRequestSender("static/year-month-list");
             WebArchiveApiCaller apiCaller = new WebArchiveApiCaller(
                 "http://localhost:8080",
                 "/wayback/available?url={url}&timestamp={timestamp}",

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+@TestPropertySource(properties = "app.scheduling.enable=false")
 @Transactional
 @SpringBootTest
 public class AcceptanceTest {

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -1,11 +1,8 @@
 package org.gsh.genidxpage;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
 import org.gsh.genidxpage.dao.WebArchiveReportMapper;
-import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
 import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
 import org.gsh.genidxpage.service.ApiCallReporter;
@@ -56,7 +53,7 @@ public class AcceptanceTest {
             archivePageController = new ArchivePageController(service);
         }
 
-        @DisplayName("요청 연월에 등록된 블로그 글이 web archive에 없으면, 리소스가 존재하지 않음을 응답으로 받는다")
+        @DisplayName("요청 연월에 등록된 블로그 글이 web archive에 없으면, 빈 응답을 받는다")
         @Test
         public void receive_not_found_msg_when_send_request() {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
@@ -66,13 +63,10 @@ public class AcceptanceTest {
             fakeWebArchiveServer.start();
 
             // 서버는 web archive server에 아카이브된 블로그 글을 요청한다
-            // web archive server는 처리할 수 없음 메시지를 반환한다
-            // 서버는 처리할 수 없는 요청임을 예외 처리기를 통해 클라이언트에게 알린다
-            assertThrows(
-                ArchivedPageNotFoundExceptioin.class, () -> {
-                    archivePageController.getBlogPostLinks("1999", "7");
-                }
-            );
+            // web archive server는 등록된 페이지가 없음을 알린다
+            // 서버는 클라이언트에게 빈 문자열로 응답한다
+            Assertions.assertThat(archivePageController.getBlogPostLinks("1999", "7").getBody())
+                .isEqualTo("");
 
             fakeWebArchiveServer.stop();
         }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -231,7 +231,7 @@ public class AcceptanceTest {
             // 입력쌍의 갯수만큼 요청을 보낸다
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
-            WebArchiveScheduler scheduler = new WebArchiveScheduler(bulkRequestSender, service);
+            WebArchiveScheduler scheduler = new WebArchiveScheduler(bulkRequestSender, service, null);
 
             // 요청 입력값을 파일로부터 읽어온다
             List<String> yearMonths = bulkRequestSender.prepareInput();

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -231,7 +231,7 @@ public class AcceptanceTest {
             // 입력쌍의 갯수만큼 요청을 보낸다
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
-            WebArchiveScheduler scheduler = new WebArchiveScheduler();
+            WebArchiveScheduler scheduler = new WebArchiveScheduler(bulkRequestSender, service);
 
             // 요청 입력값을 파일로부터 읽어온다
             List<String> yearMonths = bulkRequestSender.prepareInput();

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -160,7 +160,7 @@ public class AcceptanceTest {
 
         @DisplayName("한 번에 여러 요청을 보낸다")
         @Test
-        public void schedule_sending_two_requests_to_web_archive() throws IOException {
+        public void schedule_sending_two_requests_to_web_archive() {
             // 요청할 모든 입력쌍을 만든다
             // 입력쌍의 갯수만큼 요청을 보낸다
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
@@ -226,7 +226,7 @@ public class AcceptanceTest {
 
         @DisplayName("설정한 일정에 맞춰 여러 요청을 보낸다")
         @Test
-        public void send_scheduled_multiple_requests() throws IOException {
+        public void send_scheduled_multiple_requests() {
             // 요청할 모든 입력쌍을 만든다
             // 입력쌍의 갯수만큼 요청을 보낸다
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -132,7 +132,16 @@ public class FakeWebArchiveServer {
     }
 
     public void hasReceivedMultipleRequests(int requestCount) {
-        instance.verify(requestCount, getRequestedFor(urlPathTemplate("/wayback/available/.*")));
-        instance.verify(requestCount, getRequestedFor(urlPathTemplate("/web/[0-9]+/archives/.*")));
+        instance.verify(requestCount, getRequestedFor(urlPathTemplate("/wayback/available"))
+            .withQueryParam("url",
+                matching("http[s]?://agile.egloos.com/archives/[12][0-9]{3}/[01][0-9]"))
+            .withQueryParam("timestamp", matching("[0-9]{8}"))
+        );
+        instance.verify(requestCount,
+            getRequestedFor(urlPathTemplate("/web/{timestamp}/archives/{year}/{month}"))
+                .withPathParam("timestamp", matching("[0-9]{14}"))
+                .withPathParam("year", matching("[12][0-9]{3}"))
+                .withPathParam("month", matching("[01][0-9]"))
+        );
     }
 }

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -2,6 +2,7 @@ package org.gsh.genidxpage;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -128,5 +129,10 @@ public class FakeWebArchiveServer {
                 )
             )
         );
+    }
+
+    public void hasReceivedMultipleRequests(int requestCount) {
+        instance.verify(requestCount, getRequestedFor(urlPathTemplate("/wayback/available/.*")));
+        instance.verify(requestCount, getRequestedFor(urlPathTemplate("/web/[0-9]+/archives/.*")));
     }
 }

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -12,7 +12,6 @@ import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,7 +37,7 @@ class WebArchiveSchedulerTest {
 
     @DisplayName("요청 결과로 인덱스 파일을 만든다")
     @Test
-    public void generate_index_file_with_response() throws IOException {
+    public void generate_index_file_with_response() {
         IndexPageGenerator generator = mock(IndexPageGenerator.class);
         List<String> pageLinksList = List.of("l1", "l2", "l3");
 

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -1,0 +1,36 @@
+package org.gsh.genidxpage.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.gsh.genidxpage.service.ArchivePageService;
+import org.gsh.genidxpage.service.BulkRequestSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+class WebArchiveSchedulerTest {
+
+    static final List<String> IGNORE_REQUEST_INPUT = Collections.emptyList();
+
+    @DisplayName("여러 요청을 한 번에 보낸다")
+    @Test
+    public void schedule_to_send_multiple_requests() {
+        BulkRequestSender sender = mock(BulkRequestSender.class);
+        ArchivePageService service = mock(ArchivePageService.class);
+
+        when(sender.prepareInput()).thenReturn(IGNORE_REQUEST_INPUT);
+        when(sender.sendAll(any(), any(ArchivePageService.class))).thenReturn(List.of("l1", "l2", "l3"));
+
+        WebArchiveScheduler scheduler = new WebArchiveScheduler(sender, service);
+
+        scheduler.doSend();
+
+        verify(sender).sendAll(any(), any(ArchivePageService.class));
+    }
+
+}

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -1,15 +1,18 @@
 package org.gsh.genidxpage.scheduler;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.BulkRequestSender;
+import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -26,11 +29,25 @@ class WebArchiveSchedulerTest {
         when(sender.prepareInput()).thenReturn(IGNORE_REQUEST_INPUT);
         when(sender.sendAll(any(), any(ArchivePageService.class))).thenReturn(List.of("l1", "l2", "l3"));
 
-        WebArchiveScheduler scheduler = new WebArchiveScheduler(sender, service);
+        WebArchiveScheduler scheduler = new WebArchiveScheduler(sender, service, null);
 
         scheduler.doSend();
 
         verify(sender).sendAll(any(), any(ArchivePageService.class));
     }
 
+    @DisplayName("요청 결과로 인덱스 파일을 만든다")
+    @Test
+    public void generate_index_file_with_response() throws IOException {
+        IndexPageGenerator generator = mock(IndexPageGenerator.class);
+        List<String> pageLinksList = List.of("l1", "l2", "l3");
+
+        doNothing().when(generator).generateIndexPage(any());
+
+        WebArchiveScheduler scheduler = new WebArchiveScheduler(null, null, generator);
+
+        scheduler.doGenerate(pageLinksList);
+
+        verify(generator).generateIndexPage(any());
+    }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -6,11 +6,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.gsh.genidxpage.exception.ArchivedPageNotFoundExceptioin;
+import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfoBuilder;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
-import org.junit.jupiter.api.Assertions;
+import org.gsh.genidxpage.service.dto.EmptyArchivedPageInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -34,8 +34,8 @@ class ArchivePageServiceTest {
 
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter);
 
-        Assertions.assertThrows(ArchivedPageNotFoundExceptioin.class,
-            () -> service.findArchivedPageInfo(dto));
+        Assertions.assertThat(service.findArchivedPageInfo(dto)).isInstanceOf(
+            EmptyArchivedPageInfo.class);
 
         verify(reporter).reportArchivedPageSearch(any(CheckPostArchivedDto.class), eq(Boolean.FALSE));
     }

--- a/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
@@ -1,10 +1,12 @@
 package org.gsh.genidxpage.service;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
+import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -25,5 +27,16 @@ class BulkRequestSenderTest {
         Assertions.assertThat(
             bulkRequestSender.sendAll(List.of("2021/03", "2020/05"), sender)
         ).isEqualTo(List.of("link", "link"));
+    }
+
+    @DisplayName("요청 입력 파일을 읽는 데 실패했을 경우를 처리할 수 있다")
+    @Test
+    public void handle_fail_to_read_request_input_file() {
+        BulkRequestSender bulkRequestSender = new BulkRequestSender(IGNORE_INPUT_PATH);
+
+        assertThrows(
+            FailToReadRequestInputFileException.class,
+            () -> bulkRequestSender.prepareInput()
+        );
     }
 }


### PR DESCRIPTION
스케쥴러를 써서 일정 시간 간격으로 여러 요청을 호출하고, 호출 결과로 인덱스 파일을 생성한다

* 파일 관련 연산을 예외 처리한다

  - 일괄 요청에 필요한 요청 입력을 만들 때, 인덱스 파일을 만들 때
  - BulkRequestSender에서 요청 입력 파일 관련 연산에 실패했을 경우,
    예외를 던져도 상위 메서드에서 오류를 복구하기 어렵다
  - 이 대신, 문제가 발생한 곳에서 바로 Unchecked Exception을 던져서 어떤
    문제가 생겼는지 알 수 있도록 한다

* 요청 입력값 읽기 오류를 고친다

  - 요청 입력값을 리소스로 두고, 실행 시 읽어오도록 했다. 테스트 시에는
    정상 작동했지만 애플리케이션 실행 시에는 실패했다
  - 확인 결과 앱 실행 시 리소스는 소스 경로가 아니라 빌드된 경로에서
    읽어와야 했다. 리소스를 다루는 API를 쓰도록 바꾸고, 리소스 경로를
    고쳐서 정상 동작하도록 한다

* 실행 흐름 바꾼다

  - 실패하는 호출이 있더라도 스케쥴링한 모든 요청을 호출한다
  - 기존 실행 흐름은 여러 요청을 보내도록 설정했더라도 도중에 실패하는
    경우가 생기면 그 뒤의 호출이 멈춘다
  - 이런 상황이 생기더라도 모든 요청을 호출하도록 실행 흐름을 고친다.
    예외 처리를 삭제하고, null 객체를 도입해 호출 결과에 아카이빙 정보가
    없는 경우에도 다음 요청 호출이 이어질 수 있도록 한다
