### PR TITLE
web archive 응답에 접근 가능한 url이 없는 문제를 고친다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,10 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
     implementation 'com.mysql:mysql-connector-j'
 
-    implementation 'org.slf4j:slf4j-api:2.0.13'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+    implementation 'org.slf4j:slf4j-api:2.0.17'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -6,16 +6,19 @@ import org.gsh.genidxpage.service.dto.EmptyArchivedPageInfo;
 import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
+@Slf4j
 @Service
 public class AgileStoryArchivePageService implements ArchivePageService {
 
     private final WebArchiveApiCaller webArchiveApiCaller;
     private final ApiCallReporter reporter;
 
-    public AgileStoryArchivePageService(WebArchiveApiCaller webArchiveApiCaller, ApiCallReporter reporter) {
+    public AgileStoryArchivePageService(WebArchiveApiCaller webArchiveApiCaller,
+        ApiCallReporter reporter) {
         this.webArchiveApiCaller = webArchiveApiCaller;
         this.reporter = reporter;
     }
@@ -23,9 +26,13 @@ public class AgileStoryArchivePageService implements ArchivePageService {
     public String findBlogPageLink(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = this.findArchivedPageInfo(dto);
         if (archivedPageInfo.isEmpty()) {
+            log.info(
+                String.format("empty blog page link for %s/%s", dto.getYear(), dto.getMonth()));
             return "";
         }
         String blogPost = this.findBlogPostPage(archivedPageInfo);
+        log.info(String.format("blog page link for %s/%s: %s", dto.getYear(), dto.getMonth(),
+            this.buildPageLinks(blogPost)));
         return this.buildPageLinks(blogPost);
     }
 

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -5,6 +5,7 @@ import org.gsh.genidxpage.exception.FailToCreateDirectoryException;
 import org.gsh.genidxpage.exception.FailToWriteFileException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -12,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 
+@Slf4j
 @Component
 public class IndexPageGenerator {
 

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -49,7 +49,7 @@ public class WebArchiveApiCaller {
         return UriComponentsBuilder.fromUriString(rootUri)
             .uriComponents(
                 UriComponentsBuilder.fromUriString(checkArchivedUri)
-                    .buildAndExpand(dto.getUrl(), dto.getTimestamp())
+                    .buildAndExpand(dto.getUrl())
             )
             .build().toUriString();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ mybatis:
 
 webArchive:
   rootUri: https://archive.org
-  checkArchivedUri: /wayback/available?url={url}&timestamp={timestamp}
+  checkArchivedUri: /wayback/available?url={url}
 
 bulk-request:
   input-path: static/year-month-list


### PR DESCRIPTION
 - 로그를 추가해 확인해본 결과, web archive로부터 응답이 오지만, 응답 안에 접근 가능한 url이 없었다
 - api 문서에 따르면, timestamp 쿼리 파라미터를 명시하지 않더라도 가장 최근의 접근 가능한 캡쳐를 반환한다. 
 timestamp 쿼리 파라미터를 지웠을 때 (접근 가능한 url이 없는 경우도 있었지만), web archive 응답에 접근 
 가능한 url이 포함된 것을 확인했다
 - ref: https://archive.org/help/wayback_api.php
