### PR TITLE
CI에 테스트 추가한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: 'temurin'
       - name: check code format fits checkstyle and editconfig config
         run: ruby ./hooks/check_code_format.rb
-  build-n-test:
+  run-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,20 @@ jobs:
           distribution: 'temurin'
       - name: check code format fits checkstyle and editconfig config
         run: ruby ./hooks/check_code_format.rb
+  build-n-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      - name: build without test
+        run: ./gradlew clean && ./gradlew build -x test
+      - name: test
+        run: ./gradlew test

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.19.1'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
     implementation 'com.mysql:mysql-connector-j'
+    implementation 'com.h2database:h2'
 
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -17,6 +17,10 @@ is_editorconfig_failed = editorconfig_result.split("\n")
     l.match(/^> Task :editorconfigCheck FAILED.*/)
   } != []
 
+puts 'run test...'
+test_result = `./gradlew test 2>/dev/null`
+is_test_failed = test_result.scan('FAILED') != []
+
 if now_branch_nm.match(branch_nm_convention).nil?
   puts 'branch name does not follow the convention!'
   puts 'it should match "issue/80-blah-blah"'
@@ -36,9 +40,15 @@ if is_editorconfig_failed
 else
   puts 'editorconfig ok'
 end
+if is_test_failed
+  puts 'test failed!'
+else
+  puts 'test ok'
+end
 
 if now_branch_nm.match(branch_nm_convention).nil? or
   is_checkstyle_failed or
-  is_editorconfig_failed
+  is_editorconfig_failed or
+  is_test_failed
   exit 1
 end

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -3,12 +3,14 @@
 now_branch_nm = `git rev-parse --abbrev-ref HEAD`
 branch_nm_convention = /^issue\/[1-9][0-9]*(\w|-)+/
 
+puts 'checking checkstyle...'
 checkstyle_result = `./gradlew checkstyleMain checkstyleTest 2>/dev/null`
 is_checkstyle_failed = checkstyle_result.split("\n")
   .select {|l|
     l.match(/^> Task :checkstyleMain FAILED.*|^> Task :checkstyleTest FAILED.*/)
   } != []
 
+puts 'checking editorconfig...'
 editorconfig_result = `./gradlew editorconfigCheck 2>/dev/null`
 is_editorconfig_failed = editorconfig_result.split("\n")
   .select {|l|
@@ -18,15 +20,21 @@ is_editorconfig_failed = editorconfig_result.split("\n")
 if now_branch_nm.match(branch_nm_convention).nil?
   puts 'branch name does not follow the convention!'
   puts 'it should match "issue/80-blah-blah"'
+else
+  puts 'branch naming convention ok'
 end
 if is_checkstyle_failed
   puts 'failed to format code as configured in checkstyle!'
   puts 'run ./gradlew check for detail'
+else
+  puts 'checkstyle ok'
 end
 if is_editorconfig_failed
   puts 'trying to recover editorconfig failure...'
   puts 'commit before push'
   `./gradlew editorConfigFormat`
+else
+  puts 'editorconfig ok'
 end
 
 if now_branch_nm.match(branch_nm_convention).nil? or

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -7,9 +7,13 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class WebArchiveApiCaller {
@@ -46,10 +50,17 @@ public class WebArchiveApiCaller {
     }
 
     String buildUri(final CheckPostArchivedDto dto) {
+        UriComponents uriComponents = UriComponentsBuilder.fromUriString(checkArchivedUri).build();
+
+        List<String> queryParams = new ArrayList<>();
+        queryParams.add(dto.getUrl());
+        if (uriComponents.getQueryParams().get("timestamp") != null) {
+            queryParams.add(dto.getTimestamp());
+        }
+
         return UriComponentsBuilder.fromUriString(rootUri)
             .uriComponents(
-                UriComponentsBuilder.fromUriString(checkArchivedUri)
-                    .buildAndExpand(dto.getUrl())
+                uriComponents.expand(queryParams.toArray())
             )
             .build().toUriString();
     }

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -19,8 +19,8 @@ public class WebArchiveApiCaller {
     private final String rootUri;
 
     public WebArchiveApiCaller(
-        @Value("${webArchive.rootUri}") final String rootUri,
-        @Value("${webArchive.checkArchivedUri}") String checkArchivedUri,
+        @Value("${web-archive.root-uri}") final String rootUri,
+        @Value("${web-archive.check-archived-uri}") String checkArchivedUri,
         RestTemplateBuilder restTemplateBuilder
     ) {
         this.restTemplate = restTemplateBuilder.build();

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,17 +2,14 @@ spring:
   application:
     name: genidxpage
   datasource:
-    url: jdbc:h2:mem:test;MODE=MySQL;
-    driver-class-name: org.h2.Driver
-    username: sa
-    h2:
-      console:
-        enabled: true
-        path: /h2-console #url: localhost:8080/h2-console
+    url: jdbc:mysql://localhost:3306/genidxpage?characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
   sql:
     init:
-      platform: h2
-      mode: embedded
+      platform: mysql
+      mode: always
       schema-locations: classpath:sql/schema.sql
       data-locations: classpath:sql/data.sql
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: genidxpage
   datasource:
-    url: jdbc:h2:mem:test;MODE=MySQL;
+    url: jdbc:h2:mem:test;MODE=MySQL;NON_KEYWORDS=YEAR,MONTH
     driver-class-name: org.h2.Driver
     username: sa
     h2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,9 +19,9 @@ mybatis:
     log-impl: org.apache.ibatis.logging.slf4j.Slf4jImpl
     map-underscore-to-camel-case: true
 
-webArchive:
-  rootUri: https://archive.org
-  checkArchivedUri: /wayback/available?url={url}
+web-archive:
+  root-uri: https://archive.org
+  check-archived-uri: /wayback/available?url={url}
 
 bulk-request:
   input-path: static/year-month-list

--- a/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
@@ -90,4 +90,24 @@ class WebArchiveApiCallerTest {
             "http://localhost:8080/wayback/available\\?url=https://agile.egloos.com/archives/2023/01&timestamp=\\d{8}"
         );
     }
+
+    @DisplayName("timestamp 쿼리 파리미터 여부에 따라 동적으로 uri를 완성한다")
+    @Test
+    public void t() {
+        WebArchiveApiCaller callerWithTimestamp = new WebArchiveApiCaller("http://localhost:8080",
+            "/wayback/available?url={url}&timestamp={timestamp}",
+            CustomRestTemplateBuilder.get());
+        CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
+
+        Assertions.assertThat(callerWithTimestamp.buildUri(dto)).matches(
+            "http://localhost:8080/wayback/available\\?url=[^&]*&timestamp=\\d{8}"
+        );
+
+        WebArchiveApiCaller callerWithoutTimestamp = new WebArchiveApiCaller("http://localhost:8080",
+            "/wayback/available?url={url}",
+            CustomRestTemplateBuilder.get());
+        Assertions.assertThat(callerWithoutTimestamp.buildUri(dto)).matches(
+            "http://localhost:8080/wayback/available\\?url=[^&]*"
+        );
+    }
 }

--- a/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
@@ -93,7 +93,7 @@ class WebArchiveApiCallerTest {
 
     @DisplayName("timestamp 쿼리 파리미터 여부에 따라 동적으로 uri를 완성한다")
     @Test
-    public void t() {
+    public void build_uri_dynamically_depending_on_given_query_parameters() {
         WebArchiveApiCaller callerWithTimestamp = new WebArchiveApiCaller("http://localhost:8080",
             "/wayback/available?url={url}&timestamp={timestamp}",
             CustomRestTemplateBuilder.get());


### PR DESCRIPTION
- 깃헙액션 ci 실행 시 테스트를 실행한다
  - 실행 환경을 분리해서 테스트 환경에서는 h2를 쓰고, 운영 환경(로컬을 포함)에서는
  기존과 동일하게 mysql을 쓴다
  - 테스트 환경의 app.yaml에서 year, month를 예약어에서 제외한다. 컬럼명으로 쓰는
  year, month는 h2의 예약어라서 테스트 실행 시 쿼리가 실패하기 때문이다

- push 전에 깃 훅으로 테스트 실행한다
  - 콘솔에서 pre-push 훅 진행 상황을 알 수 있도록 로그 메시지 추가한다

- #39 로 인해 깨지는 테스트를 고친다
  - web archive 요청 url에서 timestamp 쿼리 파라미터를 제외한 다음 기존
    테스트가 실패한다. 테스트에서도 url을 만드는 기능을 공통으로 쓰는데,
    테스트에선 timestamp 쿼리 파라미터를 여전히 쓰기 때문이다
  - 추후 timestamp 쿼리 파라미터가 필요해질 수도 있어서, buildUri()에서
    주어진 url 템플릿에 명시된 쿼리 파라미터에 따라 동적으로 url을 완성하도록 변경했다
  - 즉 timestamp가 있는 url 템플릿이면 timestamp 쿼리 파라미터에도 값을
    넣고, 그렇지 않다면 url 쿼리 파라미터에만 값을 넣는다

- app.yaml 명명 규칙 케밥 케이스로 통일한다