### PR TITLE
접근 제한자 정리한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/exception/ArchivedPageNotFoundException.java
+++ b/src/main/java/org/gsh/genidxpage/exception/ArchivedPageNotFoundException.java
@@ -2,12 +2,12 @@ package org.gsh.genidxpage.exception;
 
 import org.gsh.genidxpage.common.exception.ErrorCode;
 
-public class ArchivedPageNotFoundExceptioin extends RuntimeException {
+public class ArchivedPageNotFoundException extends RuntimeException {
 
     private final ErrorCode errorCode;
     private final String message;
 
-    public ArchivedPageNotFoundExceptioin(ErrorCode errorCode, String message) {
+    public ArchivedPageNotFoundException(ErrorCode errorCode, String message) {
         super(errorCode.getReason());
         this.errorCode = errorCode;
         this.message = message;

--- a/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
@@ -1,7 +1,8 @@
-package org.gsh.genidxpage.service;
+package org.gsh.genidxpage.scheduler;
 
 import org.gsh.genidxpage.common.exception.ErrorCode;
 import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
+import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -1,7 +1,6 @@
 package org.gsh.genidxpage.scheduler;
 
 import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.service.BulkRequestSender;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -36,7 +36,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         return this.buildPageLinks(blogPost);
     }
 
-    public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
+    ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
 
         if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
@@ -48,13 +48,13 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         return archivedPageInfo;
     }
 
-    public String findBlogPostPage(final ArchivedPageInfo archivedPageInfo) {
+    String findBlogPostPage(final ArchivedPageInfo archivedPageInfo) {
         ResponseEntity<String> blogPostResponse = webArchiveApiCaller.findBlogPostPage(
             archivedPageInfo);
         return blogPostResponse.getBody();
     }
 
-    public String buildPageLinks(final String blogPost) {
+    String buildPageLinks(final String blogPost) {
         WebPageParser webPageParser = new WebPageParser();
         List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
         return webPageParser.buildPageLinks(postLinks);

--- a/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
@@ -14,7 +14,7 @@ public class ApiCallReporter {
         this.reportMapper = reportMapper;
     }
 
-    public void reportArchivedPageSearch(final CheckPostArchivedDto dto, final Boolean pageExists) {
+    void reportArchivedPageSearch(final CheckPostArchivedDto dto, final Boolean pageExists) {
         ArchivedPageUrlReport report = ArchivedPageUrlReport.from(dto, pageExists);
         reportMapper.insertReport(report);
     }

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -56,7 +56,7 @@ public class IndexPageGenerator {
         }
     }
 
-    String generateHeader() {
+    private String generateHeader() {
         return """
             <html>
               <head>
@@ -66,7 +66,7 @@ public class IndexPageGenerator {
             """;
     }
 
-    String generateFooter() {
+    private String generateFooter() {
         return """
               </body>
             </html>

--- a/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebArchiveApiCaller.java
@@ -65,11 +65,11 @@ public class WebArchiveApiCaller {
             .build().toUriString();
     }
 
-    public boolean isArchived(final ArchivedPageInfo archivedPageInfo) {
+    boolean isArchived(final ArchivedPageInfo archivedPageInfo) {
         return archivedPageInfo.isAccessible();
     }
 
-    public ResponseEntity<String> findBlogPostPage(final ArchivedPageInfo archivedPageInfo) {
+    ResponseEntity<String> findBlogPostPage(final ArchivedPageInfo archivedPageInfo) {
         return restTemplate.getForEntity(archivedPageInfo.accessibleUrl(), String.class);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
@@ -10,9 +10,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class WebPageParser {
+class WebPageParser {
 
-    public List<PostLinkInfo> findPostLinks(String stringDoc) {
+    List<PostLinkInfo> findPostLinks(String stringDoc) {
         Document doc = Jsoup.parse(stringDoc);
         Elements postLinks = doc.select(".POST_BODY > a");
 
@@ -27,7 +27,7 @@ public class WebPageParser {
         return Collections.unmodifiableList(result);
     }
 
-    public String buildPageLinks(List<PostLinkInfo> postLinks) {
+    String buildPageLinks(List<PostLinkInfo> postLinks) {
         StringBuilder result = new StringBuilder();
         for (PostLinkInfo postLink : postLinks) {
             result.append(postLink.buildPageLink());

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -7,7 +7,7 @@ import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
 import org.gsh.genidxpage.service.ApiCallReporter;
 import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.service.BulkRequestSender;
+import org.gsh.genidxpage.scheduler.BulkRequestSender;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.service.BulkRequestSender;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
+import org.gsh.genidxpage.scheduler.BulkRequestSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
- public으로 선언할 필요 없는 클래스, 메서드의 접근 제한자를 좁힌다
- BulkRequestSender 패키지를 scheduler 하위로 옮긴다
  - BulkRequestSender 구현을 service 패키지 하위의 클래스와 공유할 필요 없다
  - AcceptanceTest에서 이 클래스를 쓰고 있어서 접근 제한자를 public보다 좁게 바꿀 수 없다
  - 현재는 깔끔한 해결책이 없어서 추후 수정할 예정이다