### PR TITLE
브랜치명 규칙 수정한다

### DIFF
--- a/hooks/check_branch_name.rb
+++ b/hooks/check_branch_name.rb
@@ -1,12 +1,9 @@
 #!/usr/bin/env ruby
 
-now_branch_nm = ARGV[0]
-branch_nm_convention = /^issue-[1-9][0-9]*\/\w{1}(\w|-)*/
+require_relative './lib/branch_name_checker'
 
-puts "current branch name is #{now_branch_nm}"
-
-if now_branch_nm.match(branch_nm_convention).nil?
-  puts 'branch name does not follow the convention!'
-  puts 'it should match "issue-80/blah-blah"'
+report = BranchNameChecker.new.check(ARGV[0])
+if report.status == 'FAIL'
+  puts report.msgs.join("\n")
   exit 1
 end

--- a/hooks/check_branch_name.rb
+++ b/hooks/check_branch_name.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 
 now_branch_nm = ARGV[0]
-branch_nm_convention = /^issue\/[1-9][0-9]*(\w|-)+/
+branch_nm_convention = /^issue-[1-9][0-9]*\/\w{1}(\w|-)*/
 
 puts "current branch name is #{now_branch_nm}"
 
 if now_branch_nm.match(branch_nm_convention).nil?
   puts 'branch name does not follow the convention!'
-  puts 'it should match "issue/80-blah-blah"'
+  puts 'it should match "issue-80/blah-blah"'
   exit 1
 end

--- a/hooks/lib/branch_name_checker.rb
+++ b/hooks/lib/branch_name_checker.rb
@@ -1,0 +1,20 @@
+require_relative './hook_report'
+
+class BranchNameChecker
+  def check(now_branch_nm)
+    branch_nm_convention = /^issue-[1-9][0-9]*\/\w{1}(\w|-)*/
+
+    if now_branch_nm.match(branch_nm_convention).nil?
+      HookReport.new(
+        'FAIL',
+        ['branch name does not follow the convention!',
+         'it should match "issue-80/blah-blah"']
+      )
+    else
+      HookReport.new(
+        'SUCCESS',
+        []
+      )
+    end
+  end
+end

--- a/hooks/lib/hook_report.rb
+++ b/hooks/lib/hook_report.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+class HookReport
+  attr_accessor :status, :msgs
+
+  def initialize(status, msgs)
+    self.status = status
+    self.msgs = msgs
+  end
+
+  def to_s
+    status << "\n" << msgs.join("\n")
+  end
+end

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 now_branch_nm = `git rev-parse --abbrev-ref HEAD`
-branch_nm_convention = /^issue\/[1-9][0-9]*(\w|-)+/
+branch_nm_convention = /^issue-[1-9][0-9]*\/\w{1}(\w|-)*/
 
 puts 'checking checkstyle...'
 checkstyle_result = `./gradlew checkstyleMain checkstyleTest 2>/dev/null`
@@ -23,7 +23,7 @@ is_test_failed = test_result.scan('FAILED') != []
 
 if now_branch_nm.match(branch_nm_convention).nil?
   puts 'branch name does not follow the convention!'
-  puts 'it should match "issue/80-blah-blah"'
+  puts 'it should match "issue-80/blah-blah"'
 else
   puts 'branch naming convention ok'
 end

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 
+require_relative './lib/branch_name_checker'
+
 now_branch_nm = `git rev-parse --abbrev-ref HEAD`
-branch_nm_convention = /^issue-[1-9][0-9]*\/\w{1}(\w|-)*/
+branch_nm_report = BranchNameChecker.new.check(now_branch_nm)
 
 puts 'checking checkstyle...'
 checkstyle_result = `./gradlew checkstyleMain checkstyleTest 2>/dev/null`
@@ -21,12 +23,12 @@ puts 'run test...'
 test_result = `./gradlew test 2>/dev/null`
 is_test_failed = test_result.scan('FAILED') != []
 
-if now_branch_nm.match(branch_nm_convention).nil?
-  puts 'branch name does not follow the convention!'
-  puts 'it should match "issue-80/blah-blah"'
+if branch_nm_report.status == 'FAIL'
+  puts branch_nm_report.msgs.join("\n")
 else
   puts 'branch naming convention ok'
 end
+
 if is_checkstyle_failed
   puts 'failed to format code as configured in checkstyle!'
   puts 'run ./gradlew check for detail'
@@ -46,7 +48,7 @@ else
   puts 'test ok'
 end
 
-if now_branch_nm.match(branch_nm_convention).nil? or
+if branch_nm_report.status == 'FAIL' or
   is_checkstyle_failed or
   is_editorconfig_failed or
   is_test_failed


### PR DESCRIPTION
- 브랜치명 규칙을 수정하고, 깃 훅과 깃헙액션에 반영한다
- 브랜치명 규칙 체크 로직을 모듈화한다
  - 로직 변경 시 두 곳을 모두 바꿔야 했다. 모듈화해서 한 곳만 변경하면 되도록 한다
  - 변경 후
  BranchNameChecker는 공통 로직을 구현하고,
  HookReport는 체크 결과를 저장한다.
  기존 pre-push 훅과 깃헙액션에서 실행하는 check_branch_name 스크립트는 위 두 클래스를 쓴다