### PR TITLE
flyway 도입한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j'
     implementation 'com.h2database:h2'
 
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,12 +6,9 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
-  sql:
-    init:
-      platform: mysql
-      mode: always
-      schema-locations: classpath:sql/schema.sql
-      data-locations: classpath:sql/data.sql
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
 
 mybatis:
   mapper-locations: classpath:mapper/*Mapper.xml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,12 +9,9 @@ spring:
       console:
         enabled: true
         path: /h2-console #url: localhost:8080/h2-console
-  sql:
-    init:
-      platform: h2
-      mode: embedded
-      schema-locations: classpath:sql/schema.sql
-      data-locations: classpath:sql/data.sql
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
 
 mybatis:
   mapper-locations: classpath:mapper/*Mapper.xml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,10 +5,10 @@ spring:
     url: jdbc:h2:mem:test;MODE=MySQL;NON_KEYWORDS=YEAR,MONTH
     driver-class-name: org.h2.Driver
     username: sa
-    h2:
-      console:
-        enabled: true
-        path: /h2-console #url: localhost:8080/h2-console
+  h2:
+    console:
+      enabled: true
+      path: /h2-console #url: localhost:8080/h2-console
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS page_url_report;
-
 CREATE TABLE `page_url_report`
 (
     `id`                bigint PRIMARY KEY NOT NULL AUTO_INCREMENT,

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,10 +1,10 @@
-CREATE TABLE `page_url_report`
+CREATE TABLE page_url_report
 (
-    `id`                bigint PRIMARY KEY NOT NULL AUTO_INCREMENT,
-    `year`              varchar(255),
-    `month`             varchar(255),
-    `page_exists`        bool,
-    `created_at`        datetime,
-    `updated_at`        datetime,
-    `deleted_at`        datetime
+    id          bigint PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    year        varchar(255),
+    month       varchar(255),
+    page_exists bool,
+    created_at  datetime,
+    updated_at  datetime,
+    deleted_at  datetime
 );

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,2 +1,0 @@
-INSERT INTO page_url_report (year, month, page_exists, created_at)
-VALUES ('2021', '1', true, '2025-04-21T20:32:02.673678');


### PR DESCRIPTION
- db 스키마 설정 방식을 flyway로 바꾼다
  - 운영 환경, 테스트 환경 모두 flyway를 쓰도록 바꾼다
  - schema.sql, data.sql 삭제한다. data.sql은 기능 동작 여부 확인하기
    위한 데이터 삽입 스크립트로 더 이상 필요 없고, schema.sql과 flyway
    스크립트를 둘 다 두면 관리 포인트가 두 곳이 되어서 일원화하는 게 낫다고
    판단했다
- h2 설정 오류 고친다
  - app.yaml 들여쓰기를 잘못 설정해서 콘솔 접속이 불가능했다