### PR TITLE
db에 이미 등록된 요청이면 새로운 행을 추가하지 않고 행을 업데이트하기만 한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
@@ -10,4 +10,6 @@ public interface WebArchiveReportMapper {
     Long insertReport(ArchivedPageUrlReport report);
 
     ArchivedPageUrlReport selectReportByYearMonth(@Param("year") String year, @Param("month") String month);
+
+    void updateReport(ArchivedPageUrlReport report);
 }

--- a/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
@@ -15,6 +15,14 @@ public class ApiCallReporter {
     }
 
     void reportArchivedPageSearch(final CheckPostArchivedDto dto, final Boolean pageExists) {
+        ArchivedPageUrlReport hasReport = reportMapper.selectReportByYearMonth(dto.getYear(),
+            dto.getMonth());
+
+        if (hasReport != null) {
+            reportMapper.updateReport(ArchivedPageUrlReport.from(dto, pageExists));
+            return;
+        }
+
         ArchivedPageUrlReport report = ArchivedPageUrlReport.from(dto, pageExists);
         reportMapper.insertReport(report);
     }

--- a/src/main/resources/db/migration/V1_1__rename_report_table.sql
+++ b/src/main/resources/db/migration/V1_1__rename_report_table.sql
@@ -1,0 +1,1 @@
+alter table page_url_report rename to post_list_page_status;

--- a/src/main/resources/mapper/WebArchiveReportMapper.xml
+++ b/src/main/resources/mapper/WebArchiveReportMapper.xml
@@ -25,4 +25,13 @@
       AND `month` = #{month}
       AND deleted_at IS NULL
   </select>
+
+  <update id="updateReport" useGeneratedKeys="true" keyProperty="id"
+    parameterType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+    UPDATE post_list_page_status
+    SET page_exists = #{pageExists},
+        updated_at  = #{updatedAt}
+    WHERE `year` = #{year}
+      AND `month` = #{month}
+  </update>
 </mapper>

--- a/src/main/resources/mapper/WebArchiveReportMapper.xml
+++ b/src/main/resources/mapper/WebArchiveReportMapper.xml
@@ -6,7 +6,7 @@
   <insert id="insertReport" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
 
-    INSERT INTO page_url_report (year,
+    INSERT INTO post_list_page_status (year,
                           month,
                           page_exists,
                           created_at)
@@ -20,7 +20,7 @@
     SELECT `year`,
            `month`,
            page_exists
-    FROM page_url_report
+    FROM post_list_page_status
     WHERE `year` = #{year}
       AND `month` = #{month}
       AND deleted_at IS NULL

--- a/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
@@ -1,7 +1,9 @@
 package org.gsh.genidxpage.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
@@ -30,5 +32,25 @@ class ApiCallReporterTest {
             new CheckPostArchivedDto("2021", "3")
         );
         Assertions.assertThat(hasArchivedPage).isTrue();
+    }
+
+    @DisplayName("이미 db에 기록된 경우, 새로운 행을 추가하지 않는다")
+    @Test
+    public void only_update_status_when_page_status_already_inserted() {
+        WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
+        ApiCallReporter reporter = new ApiCallReporter(mapper);
+        ArchivedPageUrlReport report = new ArchivedPageUrlReport(
+            "2021", "3", Boolean.TRUE, LocalDateTime.now()
+        );
+
+        when(mapper.selectReportByYearMonth(any(), any())).thenReturn(
+            report);
+        doNothing().when(mapper).updateReport(report);
+
+        CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
+        reporter.reportArchivedPageSearch(dto, Boolean.TRUE);
+
+        verify(mapper).selectReportByYearMonth(any(), any());
+        verify(mapper).updateReport(any(ArchivedPageUrlReport.class));
     }
 }


### PR DESCRIPTION
- 테이블명을 바꾼다
- 연월 쌍을 중복 추가하지 않도록 해서, 추후에 요청 성공/실패 여부 기록 확인을 단순하게 만든다
- 아직 등록되지 않은 요청이면 새로 기록하고, 이미 등록된 요청이면 업데이트만 한다
- 이전 요청 결과가 성공이든 아니든 상관없이 web archive에 access url을 묻는 요청은 새로 보낸다. 왜냐하면
  - 인덱스 파일이 매번 새로 만들어지고
  - 이전 요청이 성공해서 url을 받았더라도 이걸 저장하지 않으므로
  - 현재 구현에선 스케쥴링 시점마다 access url을 다 다시 얻어와야 하기 때문이다
