### PR TITLE
접근 url로 가져온 html 형식 블로그 링크 목록을 db에 기록한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/dao/PostListPageMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostListPageMapper.java
@@ -11,5 +11,5 @@ public interface PostListPageMapper {
 
     PostListPage selectPostListPageByYearMonth(@Param("year") String year, @Param("month") String month);
 
-    void updatePostListPage(PostListPage postListPage);
+    Long updatePostListPage(PostListPage postListPage);
 }

--- a/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
@@ -7,4 +7,8 @@ import org.gsh.genidxpage.entity.Post;
 public interface PostMapper {
 
     Long insertPost(Post post);
+
+    Post selectByParentPageId(Long parentPageId);
+
+    Long updatePost(Post post);
 }

--- a/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
@@ -1,0 +1,10 @@
+package org.gsh.genidxpage.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.gsh.genidxpage.entity.Post;
+
+@Mapper
+public interface PostMapper {
+
+    Long insertPost(Post post);
+}

--- a/src/main/java/org/gsh/genidxpage/entity/Post.java
+++ b/src/main/java/org/gsh/genidxpage/entity/Post.java
@@ -1,0 +1,45 @@
+package org.gsh.genidxpage.entity;
+
+import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+
+import java.time.LocalDateTime;
+
+public class PostListPage {
+
+    private Long id;
+    private String year;
+    private String month;
+    private String url;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public PostListPage(String year, String month, String url, LocalDateTime createdAt) {
+        this.year = year;
+        this.month = month;
+        this.url = url;
+        this.createdAt = createdAt;
+    }
+
+    public static PostListPage of(CheckPostArchivedDto dto, ArchivedPageInfo archivedPageInfo) {
+        return new PostListPage(
+            dto.getYear(),
+            dto.getMonth(),
+            archivedPageInfo.accessibleUrl(),
+            LocalDateTime.now()
+        );
+    }
+
+    public String getYear() {
+        return year;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/entity/Post.java
+++ b/src/main/java/org/gsh/genidxpage/entity/Post.java
@@ -1,45 +1,41 @@
 package org.gsh.genidxpage.entity;
 
-import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
-import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
-
 import java.time.LocalDateTime;
 
-public class PostListPage {
+public class Post {
 
     private Long id;
-    private String year;
-    private String month;
-    private String url;
+    private Long parentPageId;
+    private String rawHtml;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
-    public PostListPage(String year, String month, String url, LocalDateTime createdAt) {
-        this.year = year;
-        this.month = month;
-        this.url = url;
+    public Post() {}
+
+    public Post(Long parentPageId, String rawHtml, LocalDateTime createdAt) {
+        this.parentPageId = parentPageId;
+        this.rawHtml = rawHtml;
         this.createdAt = createdAt;
     }
 
-    public static PostListPage of(CheckPostArchivedDto dto, ArchivedPageInfo archivedPageInfo) {
-        return new PostListPage(
-            dto.getYear(),
-            dto.getMonth(),
-            archivedPageInfo.accessibleUrl(),
+    public static Post of(String postLinkInfoList, Long listPageId) {
+        return new Post(
+            listPageId,
+            postLinkInfoList,
             LocalDateTime.now()
         );
     }
 
-    public String getYear() {
-        return year;
+    public Long getParentPageId() {
+        return parentPageId;
     }
 
-    public String getMonth() {
-        return month;
+    public String getRawHtml() {
+        return rawHtml;
     }
 
-    public String getUrl() {
-        return url;
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 }

--- a/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
+++ b/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
@@ -17,6 +17,14 @@ public class PostListPage {
 
     public PostListPage() {}
 
+    public PostListPage(Long id, String year, String month, String url, LocalDateTime createdAt) {
+        this.id = id;
+        this.year = year;
+        this.month = month;
+        this.url = url;
+        this.createdAt = createdAt;
+    }
+
     public PostListPage(String year, String month, String url, LocalDateTime createdAt) {
         this.year = year;
         this.month = month;
@@ -31,6 +39,10 @@ public class PostListPage {
             archivedPageInfo.accessibleUrl(),
             LocalDateTime.now()
         );
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getYear() {

--- a/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
+++ b/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
@@ -15,6 +15,8 @@ public class PostListPage {
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
+    public PostListPage() {}
+
     public PostListPage(String year, String month, String url, LocalDateTime createdAt) {
         this.year = year;
         this.month = month;

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -39,6 +39,8 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         String blogPost = this.findBlogPostPage(archivedPageInfo);
         log.info(String.format("blog page link for %s/%s: %s", dto.getYear(), dto.getMonth(),
             this.buildPageLinks(blogPost)));
+        postRecorder.record(this.buildPageLinks(blogPost), listPageId);
+
         return this.buildPageLinks(blogPost);
     }
 
@@ -65,7 +67,6 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
 
         String pageLinksConcat = webPageParser.buildPageLinks(postLinks);
-        postRecorder.record(pageLinksConcat);
 
         return pageLinksConcat;
     }

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -17,12 +17,14 @@ public class AgileStoryArchivePageService implements ArchivePageService {
     private final WebArchiveApiCaller webArchiveApiCaller;
     private final ApiCallReporter reporter;
     private final PostListPageRecorder listPageRecorder;
+    private final PostRecorder postRecorder;
 
     public AgileStoryArchivePageService(WebArchiveApiCaller webArchiveApiCaller,
-        ApiCallReporter reporter, PostListPageRecorder listPageRecorder) {
+        ApiCallReporter reporter, PostListPageRecorder listPageRecorder, PostRecorder postRecorder) {
         this.webArchiveApiCaller = webArchiveApiCaller;
         this.reporter = reporter;
         this.listPageRecorder = listPageRecorder;
+        this.postRecorder = postRecorder;
     }
 
     public String findBlogPageLink(final CheckPostArchivedDto dto) {

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -62,6 +62,10 @@ public class AgileStoryArchivePageService implements ArchivePageService {
     String buildPageLinks(final String blogPost) {
         WebPageParser webPageParser = new WebPageParser();
         List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
-        return webPageParser.buildPageLinks(postLinks);
+
+        String pageLinksConcat = webPageParser.buildPageLinks(postLinks);
+        postRecorder.record(pageLinksConcat);
+
+        return pageLinksConcat;
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -6,6 +6,7 @@ import org.gsh.genidxpage.service.dto.EmptyArchivedPageInfo;
 import org.gsh.genidxpage.web.response.PostLinkInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         this.postRecorder = postRecorder;
     }
 
+    @Transactional
     public String findBlogPageLink(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = this.findArchivedPageInfo(dto);
         if (archivedPageInfo.isEmpty()) {
@@ -35,10 +37,9 @@ public class AgileStoryArchivePageService implements ArchivePageService {
             return "";
         }
         Long listPageId = listPageRecorder.record(dto, archivedPageInfo);
+        log.info("id of post list page inserted/updated now is {" + listPageId + "}");
 
         String blogPost = this.findBlogPostPage(archivedPageInfo);
-        log.info(String.format("blog page link for %s/%s: %s", dto.getYear(), dto.getMonth(),
-            this.buildPageLinks(blogPost)));
         postRecorder.record(this.buildPageLinks(blogPost), listPageId);
 
         return this.buildPageLinks(blogPost);

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -16,13 +16,13 @@ public class AgileStoryArchivePageService implements ArchivePageService {
 
     private final WebArchiveApiCaller webArchiveApiCaller;
     private final ApiCallReporter reporter;
-    private final PostListPageRecorder recorder;
+    private final PostListPageRecorder listPageRecorder;
 
     public AgileStoryArchivePageService(WebArchiveApiCaller webArchiveApiCaller,
-        ApiCallReporter reporter, PostListPageRecorder recorder) {
+        ApiCallReporter reporter, PostListPageRecorder listPageRecorder) {
         this.webArchiveApiCaller = webArchiveApiCaller;
         this.reporter = reporter;
-        this.recorder = recorder;
+        this.listPageRecorder = listPageRecorder;
     }
 
     public String findBlogPageLink(final CheckPostArchivedDto dto) {
@@ -47,7 +47,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         }
 
         reporter.reportArchivedPageSearch(dto, Boolean.TRUE);
-        recorder.record(dto, archivedPageInfo);
+        listPageRecorder.record(dto, archivedPageInfo);
         return archivedPageInfo;
     }
 

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -34,7 +34,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
                 String.format("empty blog page link for %s/%s", dto.getYear(), dto.getMonth()));
             return "";
         }
-        listPageRecorder.record(dto, archivedPageInfo);
+        Long listPageId = listPageRecorder.record(dto, archivedPageInfo);
 
         String blogPost = this.findBlogPostPage(archivedPageInfo);
         log.info(String.format("blog page link for %s/%s: %s", dto.getYear(), dto.getMonth(),

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -34,6 +34,8 @@ public class AgileStoryArchivePageService implements ArchivePageService {
                 String.format("empty blog page link for %s/%s", dto.getYear(), dto.getMonth()));
             return "";
         }
+        listPageRecorder.record(dto, archivedPageInfo);
+
         String blogPost = this.findBlogPostPage(archivedPageInfo);
         log.info(String.format("blog page link for %s/%s: %s", dto.getYear(), dto.getMonth(),
             this.buildPageLinks(blogPost)));
@@ -49,7 +51,6 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         }
 
         reporter.reportArchivedPageSearch(dto, Boolean.TRUE);
-        listPageRecorder.record(dto, archivedPageInfo);
         return archivedPageInfo;
     }
 

--- a/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
@@ -15,17 +15,18 @@ public class PostListPageRecorder {
         this.mapper = mapper;
     }
 
-    void record(final CheckPostArchivedDto dto, final ArchivedPageInfo archivedPageInfo) {
+    Long record(final CheckPostArchivedDto dto, final ArchivedPageInfo archivedPageInfo) {
         PostListPage hasPostListPage = mapper.selectPostListPageByYearMonth(
             dto.getYear(),
             dto.getMonth()
         );
 
         if (hasPostListPage != null) {
-            mapper.updatePostListPage(PostListPage.of(dto, archivedPageInfo));
-            return;
+            Long updateId = mapper.updatePostListPage(PostListPage.of(dto, archivedPageInfo));
+            return updateId;
         }
 
-        mapper.insertPostListPage(PostListPage.of(dto, archivedPageInfo));
+        Long insertId = mapper.insertPostListPage(PostListPage.of(dto, archivedPageInfo));
+        return insertId;
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
@@ -5,7 +5,9 @@ import org.gsh.genidxpage.entity.PostListPage;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.stereotype.Repository;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Repository
 public class PostListPageRecorder {
 
@@ -22,11 +24,14 @@ public class PostListPageRecorder {
         );
 
         if (hasPostListPage != null) {
-            Long updateId = mapper.updatePostListPage(PostListPage.of(dto, archivedPageInfo));
-            return updateId;
+            log.info("updating access url with id of " + hasPostListPage.getId() + " with content of " + archivedPageInfo.accessibleUrl());
+            mapper.updatePostListPage(PostListPage.of(dto, archivedPageInfo));
+            return hasPostListPage.getId();
         }
 
-        Long insertId = mapper.insertPostListPage(PostListPage.of(dto, archivedPageInfo));
-        return insertId;
+        log.info("inserting access url of " + archivedPageInfo.accessibleUrl());
+        PostListPage postListPage = PostListPage.of(dto, archivedPageInfo);
+        mapper.insertPostListPage(postListPage);
+        return postListPage.getId();
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
@@ -24,7 +24,9 @@ public class PostListPageRecorder {
         );
 
         if (hasPostListPage != null) {
-            log.info("updating access url with id of " + hasPostListPage.getId() + " with content of " + archivedPageInfo.accessibleUrl());
+            log.info(
+                "updating access url with id of " + hasPostListPage.getId() + " with content of "
+                    + archivedPageInfo.accessibleUrl());
             mapper.updatePostListPage(PostListPage.of(dto, archivedPageInfo));
             return hasPostListPage.getId();
         }

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class PostRecorder {
 
-    public void record(String postLinkInfoList) {
+    public void record(String postLinkInfoList, Long listPageId) {
 
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -1,11 +1,20 @@
 package org.gsh.genidxpage.service;
 
+import org.gsh.genidxpage.dao.PostMapper;
+import org.gsh.genidxpage.entity.Post;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class PostRecorder {
 
-    public void record(String postLinkInfoList, Long listPageId) {
+    private final PostMapper mapper;
 
+    public PostRecorder(PostMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public void record(String postLinkInfoList, Long listPageId) {
+        Post post = Post.of(postLinkInfoList, listPageId);
+        mapper.insertPost(post);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -3,7 +3,9 @@ package org.gsh.genidxpage.service;
 import org.gsh.genidxpage.dao.PostMapper;
 import org.gsh.genidxpage.entity.Post;
 import org.springframework.stereotype.Repository;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Repository
 public class PostRecorder {
 
@@ -14,7 +16,12 @@ public class PostRecorder {
     }
 
     public void record(String postLinkInfoList, Long listPageId) {
-        Post post = Post.of(postLinkInfoList, listPageId);
-        mapper.insertPost(post);
+        Post hasPost = mapper.selectByParentPageId(listPageId);
+        if (hasPost != null) {
+            mapper.updatePost(Post.of(postLinkInfoList, listPageId));
+            return;
+        }
+
+        mapper.insertPost(Post.of(postLinkInfoList, listPageId));
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -1,0 +1,11 @@
+package org.gsh.genidxpage.service;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PostRecorder {
+
+    public void record(String postLinkInfoList) {
+
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/dto/CheckPostArchivedDto.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/CheckPostArchivedDto.java
@@ -9,7 +9,7 @@ public class CheckPostArchivedDto {
 
     public CheckPostArchivedDto(String year, String month) {
         this.year = year;
-        this.month = month;
+        this.month = String.format("%02d", Integer.parseInt(month));
         this.url = "https://agile.egloos.com/archives/" + year + "/" + String.format("%02d",
             Integer.parseInt(month));
         this.timestamp = "20230401";

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -34,4 +34,4 @@ logging:
     com.mysql.cj.jdbc: DEBUG
     org.springframework.web.client.RestTemplate: DEBUG
   pattern:
-    console: "%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %clr(%-5level) %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"
+    console: "%highlight(%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %-5level %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n)"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,4 +37,4 @@ logging:
     com.mysql.cj.jdbc: DEBUG
     org.springframework.web.client.RestTemplate: DEBUG
   pattern:
-    console: "%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %clr(%-5level) %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"
+    console: "%highlight(%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %-5level %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n)"

--- a/src/main/resources/db/migration/V1_3__add_post_link_table.sql
+++ b/src/main/resources/db/migration/V1_3__add_post_link_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE post
+(
+    id             BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    parent_page_id BIGINT             NOT NULL,
+    raw_html       TEXT               NOT NULL,
+    created_at     DATETIME,
+    updated_at     DATETIME,
+    deleted_at     DATETIME
+);
+
+ALTER TABLE post
+    ADD FOREIGN KEY (parent_page_id) REFERENCES post_list_page (id);

--- a/src/main/resources/mapper/PostListPageMapper.xml
+++ b/src/main/resources/mapper/PostListPageMapper.xml
@@ -18,7 +18,8 @@
   </insert>
 
   <select id="selectPostListPageByYearMonth" resultType="org.gsh.genidxpage.entity.PostListPage">
-    SELECT year,
+    SELECT id,
+           year,
            month,
            url
     FROM post_list_page

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.gsh.genidxpage.dao.PostMapper">
+  <insert id="insertPost" useGeneratedKeys="true" keyProperty="id"
+    parameterType="org.gsh.genidxpage.entity.Post">
+    INSERT INTO post (parent_page_id,
+                      raw_html,
+                      created_at)
+    VALUES (#{parentPageId},
+            #{rawHtml},
+            #{createdAt})
+  </insert>
+
+  <select id="selectByParentPageId" resultType="org.gsh.genidxpage.entity.Post">
+    SELECT parent_page_id,
+           raw_html,
+           created_at
+    FROM post
+    WHERE parent_page_id = #{parentPageId}
+      AND deleted_at IS NULL
+  </select>
+
+  <update id="updatePost" useGeneratedKeys="true" keyProperty="id"
+    parameterType="org.gsh.genidxpage.entity.Post">
+    UPDATE post
+    SET raw_html = #{rawHtml},
+        updated_at = #{updatedAt}
+    WHERE parent_page_id = #{parentPageId}
+  </update>
+</mapper>

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -39,7 +39,7 @@ public class AcceptanceTest {
     @Autowired
     private ApiCallReporter reporter;
     @Autowired
-    private PostListPageRecorder recorder;
+    private PostListPageRecorder listPageRecorder;
     @Autowired
     private WebArchiveReportMapper mapper;
 
@@ -52,7 +52,8 @@ public class AcceptanceTest {
                 "/wayback/available?url={url}&timestamp={timestamp}",
                 CustomRestTemplateBuilder.get()
             );
-            ArchivePageService service = new AgileStoryArchivePageService(apiCaller, reporter, recorder);
+            ArchivePageService service = new AgileStoryArchivePageService(apiCaller, reporter,
+                listPageRecorder);
 
             archivePageController = new ArchivePageController(service);
         }
@@ -155,7 +156,7 @@ public class AcceptanceTest {
                 "/wayback/available?url={url}&timestamp={timestamp}",
                 CustomRestTemplateBuilder.get()
             );
-            service = new AgileStoryArchivePageService(apiCaller, reporter, recorder);
+            service = new AgileStoryArchivePageService(apiCaller, reporter, listPageRecorder);
         }
 
         @DisplayName("한 번에 여러 요청을 보낸다")

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -10,6 +10,7 @@ import org.gsh.genidxpage.service.ApiCallReporter;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.gsh.genidxpage.service.PostListPageRecorder;
+import org.gsh.genidxpage.service.PostRecorder;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.ArchivePageController;
@@ -41,6 +42,8 @@ public class AcceptanceTest {
     @Autowired
     private PostListPageRecorder listPageRecorder;
     @Autowired
+    private PostRecorder postRecorder;
+    @Autowired
     private WebArchiveReportMapper mapper;
 
     @Nested
@@ -53,7 +56,7 @@ public class AcceptanceTest {
                 CustomRestTemplateBuilder.get()
             );
             ArchivePageService service = new AgileStoryArchivePageService(apiCaller, reporter,
-                listPageRecorder, null);
+                listPageRecorder, postRecorder);
 
             archivePageController = new ArchivePageController(service);
         }
@@ -156,7 +159,7 @@ public class AcceptanceTest {
                 "/wayback/available?url={url}&timestamp={timestamp}",
                 CustomRestTemplateBuilder.get()
             );
-            service = new AgileStoryArchivePageService(apiCaller, reporter, listPageRecorder, null);
+            service = new AgileStoryArchivePageService(apiCaller, reporter, listPageRecorder, postRecorder);
         }
 
         @DisplayName("한 번에 여러 요청을 보낸다")

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -53,7 +53,7 @@ public class AcceptanceTest {
                 CustomRestTemplateBuilder.get()
             );
             ArchivePageService service = new AgileStoryArchivePageService(apiCaller, reporter,
-                listPageRecorder);
+                listPageRecorder, null);
 
             archivePageController = new ArchivePageController(service);
         }
@@ -156,7 +156,7 @@ public class AcceptanceTest {
                 "/wayback/available?url={url}&timestamp={timestamp}",
                 CustomRestTemplateBuilder.get()
             );
-            service = new AgileStoryArchivePageService(apiCaller, reporter, listPageRecorder);
+            service = new AgileStoryArchivePageService(apiCaller, reporter, listPageRecorder, null);
         }
 
         @DisplayName("한 번에 여러 요청을 보낸다")

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -85,7 +85,7 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             fakeWebArchiveServer.respondItHasArchivedPage();
-            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "3", false);
+            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "03", false);
 
             fakeWebArchiveServer.start();
 
@@ -93,8 +93,8 @@ public class AcceptanceTest {
             ResponseEntity<String> response = archivePageController.getBlogPostLinks("2021", "3");
 
             // web archive server는 주어진 연월의 블로그 글 목록 페이지를 반환한다
-            Assertions.assertThat(response.getBody()).isEqualTo(
-                "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">올해 첫 AC2 과정 40기가 곧 열립니다</a>"
+            Assertions.assertThat(response.getBody()).matches(
+                "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">.* 첫 AC2 과정 40기가 곧 열립니다</a>"
             );
             Assertions.assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
 
@@ -107,7 +107,7 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             fakeWebArchiveServer.respondItHasArchivedPage();
-            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "3", true);
+            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "03", true);
 
             fakeWebArchiveServer.start();
 
@@ -116,7 +116,7 @@ public class AcceptanceTest {
 
             // web archive server는 주어진 연월의 블로그 글 목록 페이지를 반환한다
             Assertions.assertThat(response.getBody()).isEqualTo(
-                "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">올해 첫 AC2 과정 40기가 곧 열립니다</a>\n"
+                "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">2021년 03월 첫 AC2 과정 40기가 곧 열립니다</a>\n"
                     + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>\n"
                     + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
             );
@@ -131,7 +131,7 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             fakeWebArchiveServer.respondItHasArchivedPage();
-            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "3", false);
+            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth("2021", "03", false);
 
             fakeWebArchiveServer.start();
 

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -28,8 +28,8 @@ public class FakeWebArchiveServer {
     public void respondBlogPostListInGivenYearMonth(String year, String month,
         boolean hasManyPost) {
         instance.stubFor(get(urlPathTemplate("/web/20230614220926/archives/{year}/{month}"))
-            .withPathParam("year", matching("[12][0-9]{3}"))
-            .withPathParam("month", matching("[01][0-9]"))
+            .withPathParam("year", matching(year))
+            .withPathParam("month", matching(month))
             .willReturn(aResponse().withStatus(200)
                 .withBody(
                     buildPostListPage(year, month, hasManyPost)
@@ -72,10 +72,10 @@ public class FakeWebArchiveServer {
             """;
 
         String firstPostTemplate = """
-            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">YEAR/MONTH/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">올해 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">YEAR/MONTH/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">YEAR년 MONTH월 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
             """;
-        String firstPost = firstPostTemplate.replace("YEAR", year)
-            .replace("MONTH", month);
+        String firstPost = firstPostTemplate.replaceAll("YEAR", year)
+            .replaceAll("MONTH", month);
         String otherPosts = """
             <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
             <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/27</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
@@ -89,7 +89,7 @@ public class FakeWebArchiveServer {
 
     public void respondItHasArchivedPageFor(String year, String month) {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
-            .withQueryParam("url", matching("http[s]?://agile.egloos.com/archives/[12][0-9]{3}/[01][0-9]"))
+            .withQueryParam("url", matching(String.format("http[s]?://agile.egloos.com/archives/%s/%s", year, month)))
             .withQueryParam("timestamp", matching("[0-9]{8}"))
             .willReturn(aResponse().withStatus(200).withBody(
                     String.format("""

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -81,12 +81,12 @@ class ArchivePageServiceTest {
         );
         when(caller.isArchived(any())).thenReturn(true);
 
-        PostListPageRecorder recorder = mock(PostListPageRecorder.class);
+        PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller,
-            mock(ApiCallReporter.class), recorder);
+            mock(ApiCallReporter.class), listPageRecorder);
 
         service.findArchivedPageInfo(dto);
 
-        verify(recorder).record(any(CheckPostArchivedDto.class), any(ArchivedPageInfo.class));
+        verify(listPageRecorder).record(any(CheckPostArchivedDto.class), any(ArchivedPageInfo.class));
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -86,23 +86,20 @@ class ArchivePageServiceTest {
     @Test
     public void write_post_link_parsed_from_list_page_to_db() {
         PostRecorder postRecorder = mock(PostRecorder.class);
+        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
+        respondsValidBlogPostPage(caller);
+
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(
-            mock(WebArchiveApiCaller.class),
+            caller,
             mock(ApiCallReporter.class),
             mock(PostListPageRecorder.class),
             postRecorder
         );
 
-        service.buildPageLinks(
-            """
-                  <div class="POST_BODY">
-                  <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
-                  <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/14</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
-                  <div style="margin-top:10px;"><a href="/web/20230614124528/http://agile.egloos.com/archives/2020/02/page/1" title="전체보기">"2020년02월" 의 글 내용 전체 보기</a></div>
-                </div>
-                """);
+        CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
+        service.findBlogPageLink(dto);
 
-        verify(postRecorder).record(any());
+        verify(postRecorder).record(any(), any());
     }
 
     private void respondsValidBlogPostPage(WebArchiveApiCaller caller) {

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -32,7 +32,7 @@ class ArchivePageServiceTest {
         );
         ApiCallReporter reporter = mock(ApiCallReporter.class);
 
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter, null);
+        AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter, null, null);
 
         Assertions.assertThat(service.findArchivedPageInfo(dto)).isInstanceOf(
             EmptyArchivedPageInfo.class);
@@ -58,7 +58,7 @@ class ArchivePageServiceTest {
         ApiCallReporter reporter = mock(ApiCallReporter.class);
 
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter,
-            mock(PostListPageRecorder.class));
+            mock(PostListPageRecorder.class), null);
 
         service.findArchivedPageInfo(dto);
 
@@ -83,10 +83,33 @@ class ArchivePageServiceTest {
 
         PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller,
-            mock(ApiCallReporter.class), listPageRecorder);
+            mock(ApiCallReporter.class), listPageRecorder, null);
 
         service.findArchivedPageInfo(dto);
 
         verify(listPageRecorder).record(any(CheckPostArchivedDto.class), any(ArchivedPageInfo.class));
+    }
+
+    @DisplayName("블로그 글 목록 페이지로부터 파싱한 블로그 링크 목록을 db에 기록한다")
+    @Test
+    public void write_post_link_parsed_from_list_page_to_db() {
+        PostRecorder postRecorder = mock(PostRecorder.class);
+        AgileStoryArchivePageService service = new AgileStoryArchivePageService(
+            mock(WebArchiveApiCaller.class),
+            mock(ApiCallReporter.class),
+            mock(PostListPageRecorder.class),
+            postRecorder
+        );
+
+        service.buildPageLinks(
+            """
+                  <div class="POST_BODY">
+                  <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
+                  <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/14</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
+                  <div style="margin-top:10px;"><a href="/web/20230614124528/http://agile.egloos.com/archives/2020/02/page/1" title="전체보기">"2020년02월" 의 글 내용 전체 보기</a></div>
+                </div>
+                """);
+
+        verify(postRecorder).record(any());
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -69,30 +69,14 @@ class ArchivePageServiceTest {
     @DisplayName("페이지 아키이빙 정보를 찾았을 때, 접근 url을 db에 기록한다")
     @Test
     public void write_access_url_to_db_when_page_archive_info_found() {
-        ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
-            .url("url")
-            .withAccessibleArchivedSnapshots()
-            .timestamp("20240101")
-            .build();
-        CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
-
         WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
-        when(caller.findArchivedPageInfo(any())).thenReturn(
-            archivedPageInfo
-        );
-        when(caller.isArchived(any())).thenReturn(true);
-        when(caller.findBlogPostPage(any())).thenReturn(ResponseEntity.ok().body("""
-              <div class="POST_BODY">
-              <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
-              <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/14</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
-              <div style="margin-top:10px;"><a href="/web/20230614124528/http://agile.egloos.com/archives/2020/02/page/1" title="전체보기">"2020년02월" 의 글 내용 전체 보기</a></div>
-            </div>
-            """));
+        respondsValidBlogPostPage(caller);
 
         PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller,
             mock(ApiCallReporter.class), listPageRecorder, mock(PostRecorder.class));
 
+        CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
         service.findBlogPageLink(dto);
 
         verify(listPageRecorder).record(any(CheckPostArchivedDto.class), any(ArchivedPageInfo.class));
@@ -120,4 +104,25 @@ class ArchivePageServiceTest {
 
         verify(postRecorder).record(any());
     }
+
+    private void respondsValidBlogPostPage(WebArchiveApiCaller caller) {
+        ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
+            .url("url")
+            .withAccessibleArchivedSnapshots()
+            .timestamp("20240101")
+            .build();
+
+        when(caller.findArchivedPageInfo(any())).thenReturn(
+            archivedPageInfo
+        );
+        when(caller.isArchived(any())).thenReturn(true);
+        when(caller.findBlogPostPage(any())).thenReturn(ResponseEntity.ok().body("""
+              <div class="POST_BODY">
+              <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
+              <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/14</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
+              <div style="margin-top:10px;"><a href="/web/20230614124528/http://agile.egloos.com/archives/2020/02/page/1" title="전체보기">"2020년02월" 의 글 내용 전체 보기</a></div>
+            </div>
+            """));
+    }
+
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -13,6 +13,7 @@ import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.service.dto.EmptyArchivedPageInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 
 class ArchivePageServiceTest {
 
@@ -80,12 +81,19 @@ class ArchivePageServiceTest {
             archivedPageInfo
         );
         when(caller.isArchived(any())).thenReturn(true);
+        when(caller.findBlogPostPage(any())).thenReturn(ResponseEntity.ok().body("""
+              <div class="POST_BODY">
+              <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
+              <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2020/02/14</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
+              <div style="margin-top:10px;"><a href="/web/20230614124528/http://agile.egloos.com/archives/2020/02/page/1" title="전체보기">"2020년02월" 의 글 내용 전체 보기</a></div>
+            </div>
+            """));
 
         PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller,
-            mock(ApiCallReporter.class), listPageRecorder, null);
+            mock(ApiCallReporter.class), listPageRecorder, mock(PostRecorder.class));
 
-        service.findArchivedPageInfo(dto);
+        service.findBlogPageLink(dto);
 
         verify(listPageRecorder).record(any(CheckPostArchivedDto.class), any(ArchivedPageInfo.class));
     }

--- a/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
@@ -3,6 +3,7 @@ package org.gsh.genidxpage.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.gsh.genidxpage.dao.PostMapper;
 import org.gsh.genidxpage.entity.Post;
@@ -20,5 +21,17 @@ class PostRecorderTest {
         recorder.record("", 0L);
 
         verify(mapper).insertPost(any(Post.class));
+    }
+
+    @DisplayName("db에 부모 페이지 아이디에 연결된 html이 이미 기록되어 있으면, 업데이트한다")
+    @Test
+    public void only_update_when_raw_html_for_given_parent_page_already_written() {
+        PostMapper mapper = mock(PostMapper.class);
+        PostRecorder recorder = new PostRecorder(mapper);
+
+        when(mapper.selectByParentPageId(any())).thenReturn(Post.of("", 0L));
+        recorder.record("", 0L);
+
+        verify(mapper).updatePost(any(Post.class));
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
@@ -1,0 +1,24 @@
+package org.gsh.genidxpage.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.gsh.genidxpage.dao.PostMapper;
+import org.gsh.genidxpage.entity.Post;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostRecorderTest {
+
+    @DisplayName("db에 블로그 링크 목록을 나타내는 html을 기록한다")
+    @Test
+    public void write_raw_html_of_link_list_to_db() {
+        PostMapper mapper = mock(PostMapper.class);
+        PostRecorder recorder = new PostRecorder(mapper);
+
+        recorder.record("", 0L);
+
+        verify(mapper).insertPost(any(Post.class));
+    }
+}


### PR DESCRIPTION
- html 형식 블로그 링크 목록을 db에 기록한다
  - db에 기록하지 않으면 연월이 정렬된 인덱스 파일 생성이 어렵다
  - 기존 구현은 성공한 요청과 재시도한 요청의 블로그 링크 목록을 메모리에서만 가지고 있기 때문에,
  블로그 링크 목록을 연월 기준으로 정렬할 수 없기 때문이다
  - db에 기록해서 인덱스 파일 내용이 연월별로 정렬될 수 있게 준비한다

- post 테이블에 링크 목록이 표시된 html을 기록한다
  - post는 post_list_page 테이블의 id를 외래키로 갖는다. 따라서 post를 기록할 때
  연결된 post_list_page의 id가 필요하다
  - post_list_page 기록 시 insert/update 된 행의 아이디를 반환하도록 바꾸고,
  post 기록 시점에 post_list_page id 값을 알아내기 수월하도록
  post_list_page 기록 시점을 findBlogPageLink()로 바꾼다

- PostListPage insert/update 오류 고친다
  - PostListPageRecorder에서 post_list_page를 db에 기록할 때 기존에 기록된
    post_list_page가 있는지 확인하는 로직에 오류가 있었다
  - mapper xml에서 insert/update 시 기록한 행의 id 값을 인자의 id 필드에
    넣어주는데, 이 값을 쓰지 않고 (db에 기록된 행의 갯수를 나타내는)
    메서드 반환값을 써서 post_list_page를 update해야 하는 경우에도 insert하는
    오류가 나고 있었다. 발생하지 않게 로직을 고친다

- selectPostListPageByYearMonth 검색 인자 오류 고친다
  - PostListPage의 month는 db에 항상 두 자리수로 기록된다. 하지만
    PostListPageRecorder.record() 실행 시 selectPostListPageByYearMonth()
    에 인자로 주는 CheckPostArchivedDto의 month 값은 항상 두 자리임을
    보장하지 않고 있어서 검색이 제대로 되지 않는 경우가 생겼다
  - 항상 두 자리의 month 값을 갖도록 고친다

- 테스트 정리한다
  - 공통으로 쓸 WebArchiveApiCaller 행위 정의를 메서드로 만든다
  - 인수 테스트 오류 고친다
    - FakeWebArchiveServer가 특정 연월에 대한 요청을 받았을 때, 각 연월마다
      다른 응답값을 보내도록 고친다
    - 위 변경을 기존 테스트에 반영하기 위해 연월의 월이 한 자리일 때 앞에
      꼭 0이 붙도록 바꾼다
    - 어떤 연월 값으로 요청했는지 확인하기 용이하도록, 블로그 링크가 포함된
      html에 연월이 나오도록 바꾼다

- 로그 레벨별로 색깔 구분한다