### PR TITLE
db에 저장한 링크 목록으로 인덱스 페이지를 만든다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16' // jdbc 로그 출력
 
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
@@ -3,6 +3,8 @@ package org.gsh.genidxpage.dao;
 import org.apache.ibatis.annotations.Mapper;
 import org.gsh.genidxpage.entity.Post;
 
+import java.util.List;
+
 @Mapper
 public interface PostMapper {
 
@@ -11,4 +13,6 @@ public interface PostMapper {
     Post selectByParentPageId(Long parentPageId);
 
     Long updatePost(Post post);
+
+    List<Post> selectAll();
 }

--- a/src/main/java/org/gsh/genidxpage/entity/Post.java
+++ b/src/main/java/org/gsh/genidxpage/entity/Post.java
@@ -19,10 +19,10 @@ public class Post {
         this.createdAt = createdAt;
     }
 
-    public static Post of(String postLinkInfoList, Long listPageId) {
+    public static Post of(String rawHtml, Long listPageId) {
         return new Post(
             listPageId,
-            postLinkInfoList,
+            rawHtml,
             LocalDateTime.now()
         );
     }

--- a/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
@@ -42,8 +42,7 @@ public class BulkRequestSender {
         return yearMonths;
     }
 
-    public List<String> sendAll(List<String> yearMonths, ArchivePageService sender) {
-        ArrayList<String> pageLinksList = new ArrayList<>();
+    public void sendAll(List<String> yearMonths, ArchivePageService sender) {
         yearMonths.forEach(yearMonth -> {
             // 외부 서버에 요청할 입력 형식으로 파일 내용을 정제한다
             String[] pair = yearMonth.split("/");
@@ -51,10 +50,7 @@ public class BulkRequestSender {
             String month = pair[1];
             CheckPostArchivedDto dto = new CheckPostArchivedDto(year, month);
 
-            String pageLinks = sender.findBlogPageLink(dto);
-            pageLinksList.add(pageLinks);
+            sender.findBlogPageLink(dto);
         });
-
-        return pageLinksList;
     }
 }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -28,9 +28,9 @@ public class WebArchiveScheduler {
         doGenerate(pageLinkList);
     }
 
-    public List<String> doSend() {
+    public void doSend() {
         List<String> yearMonths = bulkRequestSender.prepareInput();
-        return bulkRequestSender.sendAll(yearMonths, archivePageService);
+        bulkRequestSender.sendAll(yearMonths, archivePageService);
     }
 
     List<String> readIndexContent() {

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -23,13 +23,18 @@ public class WebArchiveScheduler {
 
     @Scheduled(cron = "0 0 * * * *")
     public void scheduleSend() {
-        List<String> pageLinkList = doSend();
+        doSend();
+        List<String> pageLinkList = readIndexContent();
         doGenerate(pageLinkList);
     }
 
     public List<String> doSend() {
         List<String> yearMonths = bulkRequestSender.prepareInput();
         return bulkRequestSender.sendAll(yearMonths, archivePageService);
+    }
+
+    List<String> readIndexContent() {
+        return archivePageService.readIndexContent();
     }
 
     void doGenerate(List<String> pageLinkList) {

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -45,6 +45,11 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         return this.buildPageLinks(blogPost);
     }
 
+    @Override
+    public List<String> readIndexContent() {
+        return List.of();
+    }
+
     ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
 

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -47,7 +47,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
 
     @Override
     public List<String> readIndexContent() {
-        return List.of();
+        return postRecorder.readAllRawHtml();
     }
 
     ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -2,7 +2,11 @@ package org.gsh.genidxpage.service;
 
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 
+import java.util.List;
+
 public interface ArchivePageService {
 
     String findBlogPageLink(final CheckPostArchivedDto dto);
+
+    List<String> readIndexContent();
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -18,14 +18,14 @@ public class PostRecorder {
         this.mapper = mapper;
     }
 
-    public void record(String postLinkInfoList, Long listPageId) {
+    public void record(String rawHtml, Long listPageId) {
         Post hasPost = mapper.selectByParentPageId(listPageId);
         if (hasPost != null) {
-            mapper.updatePost(Post.of(postLinkInfoList, listPageId));
+            mapper.updatePost(Post.of(rawHtml, listPageId));
             return;
         }
 
-        mapper.insertPost(Post.of(postLinkInfoList, listPageId));
+        mapper.insertPost(Post.of(rawHtml, listPageId));
     }
 
     public List<String> readAllRawHtml() {

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Repository
@@ -28,6 +29,9 @@ public class PostRecorder {
     }
 
     public List<String> readAllRawHtml() {
-        return null;
+        return mapper.selectAll()
+            .stream()
+            .map(post -> post.getRawHtml())
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -5,6 +5,8 @@ import org.gsh.genidxpage.entity.Post;
 import org.springframework.stereotype.Repository;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+
 @Slf4j
 @Repository
 public class PostRecorder {
@@ -23,5 +25,9 @@ public class PostRecorder {
         }
 
         mapper.insertPost(Post.of(postLinkInfoList, listPageId));
+    }
+
+    public List<String> readAllRawHtml() {
+        return null;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,8 @@ spring:
   application:
     name: genidxpage
   datasource:
-    url: jdbc:h2:mem:test;MODE=MySQL;NON_KEYWORDS=YEAR,MONTH
-    driver-class-name: org.h2.Driver
+    url: jdbc:log4jdbc:h2:mem:test;MODE=MySQL;NON_KEYWORDS=YEAR,MONTH # jdbc:h2:mem:test;MODE=MySQL;NON_KEYWORDS=YEAR,MONTH
+    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy # org.h2.Driver
     username: sa
   h2:
     console:
@@ -36,5 +36,12 @@ logging:
     org.mybatis: DEBUG
     com.mysql.cj.jdbc: DEBUG
     org.springframework.web.client.RestTemplate: DEBUG
+    jdbc:
+      sqlonly: off # sql문 출력
+      sqltiming: info # sql문과 이 sql문을 수행하는 시간(ms)
+      resultsettable: info # sql 결과로 조회된 데이터를 테이블 형태로 출력
+      audit: off # resultset을 제외한 모든 jdbc 호출 정보
+      resultset: off # resultset을 포함한 모든 jdbc 호출 정보
+      connection: off # db 연결, 연결 해제와 관련된 로그
   pattern:
     console: "%highlight(%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %-5level %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n)"

--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -30,4 +30,13 @@
         updated_at = #{updatedAt}
     WHERE parent_page_id = #{parentPageId}
   </update>
+
+  <select id="selectAll" resultType="org.gsh.genidxpage.entity.Post">
+    SELECT parent_page_id,
+           raw_html,
+           created_at
+    FROM post
+    WHERE raw_html IS NOT NULL
+      AND deleted_at IS NULL
+  </select>
 </mapper>

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -183,12 +183,10 @@ public class AcceptanceTest {
 
             fakeWebArchiveServer.start();
 
-            List<String> pageLinksList = bulkRequestSender.sendAll(yearMonths, service);
+            bulkRequestSender.sendAll(yearMonths, service);
 
-            pageLinksList.stream().forEach(pageLinks -> {
-                // 외부 서버로부터 가져온 모든 결과값은 링크 형식이다
-                Assertions.assertThat(pageLinks).matches("<a href=\".*\">.*</a>");
-            });
+            // TODO
+            //  정상 실행되었음을 단정해야 한다
 
             fakeWebArchiveServer.stop();
         }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -214,7 +214,8 @@ public class AcceptanceTest {
             fakeWebArchiveServer.start();
 
             // 입력쌍의 갯수만큼 요청을 보낸다
-            List<String> pageLinksList = bulkRequestSender.sendAll(yearMonths, service);
+            bulkRequestSender.sendAll(yearMonths, service);
+            List<String> pageLinksList = service.readIndexContent(); // db에서 인덱스에 쓸 내용을 가져온다
 
             IndexPageGenerator generator = new IndexPageGenerator(
                 "/tmp/genidxpage/test"

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -162,35 +162,6 @@ public class AcceptanceTest {
             service = new AgileStoryArchivePageService(apiCaller, reporter, listPageRecorder, postRecorder);
         }
 
-        @DisplayName("한 번에 여러 요청을 보낸다")
-        @Test
-        public void schedule_sending_two_requests_to_web_archive() {
-            // 요청할 모든 입력쌍을 만든다
-            // 입력쌍의 갯수만큼 요청을 보낸다
-            FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
-
-            // 요청 입력값을 파일로부터 읽어온다
-            List<String> yearMonths = bulkRequestSender.prepareInput();
-
-            yearMonths.forEach(yearMonth -> {
-                String[] pair = yearMonth.split("/");
-                String year = pair[0];
-                String month = pair[1];
-                // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
-                fakeWebArchiveServer.respondItHasArchivedPageFor(year, month);
-                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
-            });
-
-            fakeWebArchiveServer.start();
-
-            bulkRequestSender.sendAll(yearMonths, service);
-
-            // TODO
-            //  정상 실행되었음을 단정해야 한다
-
-            fakeWebArchiveServer.stop();
-        }
-
         @DisplayName("블로그 글 링크 목록으로 인덱스 파일을 생성한다")
         @Test
         public void generate_index_file_using_blog_post_links() throws IOException {

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -147,7 +147,7 @@ public class AcceptanceTest {
     }
 
     private BulkRequestSender bulkRequestSender;
-    private AgileStoryArchivePageService service;
+    private ArchivePageService service;
 
     @Nested
     class ArchivePageSchedulingTest {
@@ -173,11 +173,8 @@ public class AcceptanceTest {
                 new IndexPageGenerator("/tmp/genidxpage/test")
             );
 
-            // 요청 입력값을 파일로부터 읽어온다
-            List<String> yearMonths = bulkRequestSender.prepareInput();
-
             // 요청할 모든 입력쌍을 만든다
-            yearMonths.forEach(yearMonth -> {
+            List.of("2021/03", "2020/05").forEach(yearMonth -> {
                 String[] pair = yearMonth.split("/");
                 String year = pair[0];
                 String month = pair[1];
@@ -205,11 +202,15 @@ public class AcceptanceTest {
             // 입력쌍의 갯수만큼 요청을 보낸다
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
-            WebArchiveScheduler scheduler = new WebArchiveScheduler(bulkRequestSender, service, null);
+            WebArchiveScheduler scheduler = new WebArchiveScheduler(
+                bulkRequestSender,
+                service,
+                null
+            );
 
             // 요청 입력값을 파일로부터 읽어온다
-            List<String> yearMonths = bulkRequestSender.prepareInput();
-            yearMonths.forEach(yearMonth -> {
+            List<String> requestInput = List.of("2021/03", "2020/05");
+            requestInput.forEach(yearMonth -> {
                 String[] pair = yearMonth.split("/");
                 String year = pair[0];
                 String month = pair[1];
@@ -221,7 +222,7 @@ public class AcceptanceTest {
             fakeWebArchiveServer.start();
 
             scheduler.doSend();
-            fakeWebArchiveServer.hasReceivedMultipleRequests(yearMonths.size());
+            fakeWebArchiveServer.hasReceivedMultipleRequests(requestInput.size());
 
             fakeWebArchiveServer.stop();
         }
@@ -234,8 +235,8 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             // 요청할 모든 입력쌍을 만든다
-            List<String> yearMonths = bulkRequestSender.prepareInput();
-            List<String> passRequests = yearMonths.stream()
+            List<String> requestInput = List.of("2021/03", "2020/05");
+            List<String> passRequests = requestInput.stream()
                 .filter(ym -> ym.split("/")[0].equals("2021"))
                 .toList();
             passRequests.forEach(yearMonth -> {
@@ -246,7 +247,7 @@ public class AcceptanceTest {
                 fakeWebArchiveServer.respondItHasArchivedPageFor(year, month);
                 fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
             });
-            List<String> failRequests = yearMonths.stream()
+            List<String> failRequests = requestInput.stream()
                 .filter(ym -> !ym.split("/")[0].equals("2021"))
                 .toList();
             failRequests.forEach(yearMonth -> {

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -167,6 +167,12 @@ public class AcceptanceTest {
         public void generate_index_file_using_blog_post_links() throws IOException {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
+            WebArchiveScheduler scheduler = new WebArchiveScheduler(
+                bulkRequestSender,
+                service,
+                new IndexPageGenerator("/tmp/genidxpage/test")
+            );
+
             // 요청 입력값을 파일로부터 읽어온다
             List<String> yearMonths = bulkRequestSender.prepareInput();
 
@@ -183,13 +189,7 @@ public class AcceptanceTest {
             fakeWebArchiveServer.start();
 
             // 입력쌍의 갯수만큼 요청을 보낸다
-            bulkRequestSender.sendAll(yearMonths, service);
-            List<String> pageLinksList = service.readIndexContent(); // db에서 인덱스에 쓸 내용을 가져온다
-
-            IndexPageGenerator generator = new IndexPageGenerator(
-                "/tmp/genidxpage/test"
-            );
-            generator.generateIndexPage(pageLinksList);
+            scheduler.scheduleSend();
 
             Assertions.assertThat(
                 Files.readString(Path.of("/tmp/genidxpage/test/index.html"), StandardCharsets.UTF_8)

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -48,4 +48,20 @@ class WebArchiveSchedulerTest {
 
         verify(generator).generateIndexPage(any());
     }
+
+    @DisplayName("db에서 인덱스 파일 생성에 쓸 블로그 링크 html을 가져온다")
+    @Test
+    public void read_index_content_from_db() {
+        ArchivePageService service = mock(ArchivePageService.class);
+
+        WebArchiveScheduler scheduler = new WebArchiveScheduler(
+            mock(BulkRequestSender.class),
+            service,
+            null
+        );
+
+        scheduler.readIndexContent();
+
+        verify(service).readIndexContent();
+    }
 }

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -25,7 +25,7 @@ class WebArchiveSchedulerTest {
         ArchivePageService service = mock(ArchivePageService.class);
 
         when(sender.prepareInput()).thenReturn(IGNORE_REQUEST_INPUT);
-        when(sender.sendAll(any(), any(ArchivePageService.class))).thenReturn(List.of("l1", "l2", "l3"));
+        doNothing().when(sender).sendAll(any(), any(ArchivePageService.class));
 
         WebArchiveScheduler scheduler = new WebArchiveScheduler(sender, service, null);
 

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -102,6 +102,25 @@ class ArchivePageServiceTest {
         verify(postRecorder).record(any(), any());
     }
 
+    @DisplayName("기록된 블로그 링크 html 전체를 db에서 읽어온다")
+    @Test
+    public void read_all_raw_html_from_db() {
+        PostRecorder postRecorder = mock(PostRecorder.class);
+        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
+        respondsValidBlogPostPage(caller);
+
+        AgileStoryArchivePageService service = new AgileStoryArchivePageService(
+            caller,
+            mock(ApiCallReporter.class),
+            mock(PostListPageRecorder.class),
+            postRecorder
+        );
+
+        service.readIndexContent();
+
+        verify(postRecorder).readAllRawHtml();
+    }
+
     private void respondsValidBlogPostPage(WebArchiveApiCaller caller) {
         ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
             .url("url")

--- a/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
@@ -3,9 +3,10 @@ package org.gsh.genidxpage.service;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
 import org.gsh.genidxpage.scheduler.BulkRequestSender;
 import org.junit.jupiter.api.DisplayName;
@@ -25,9 +26,9 @@ class BulkRequestSenderTest {
 
         when(sender.findBlogPageLink(any())).thenReturn("link");
 
-        Assertions.assertThat(
-            bulkRequestSender.sendAll(List.of("2021/03", "2020/05"), sender)
-        ).isEqualTo(List.of("link", "link"));
+        bulkRequestSender.sendAll(List.of("2021/03", "2020/05"), sender);
+
+        verify(sender, times(2)).findBlogPageLink(any());
     }
 
     @DisplayName("요청 입력 파일을 읽는 데 실패했을 경우를 처리할 수 있다")

--- a/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
@@ -5,10 +5,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.dao.PostMapper;
 import org.gsh.genidxpage.entity.Post;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 class PostRecorderTest {
 
@@ -33,5 +36,29 @@ class PostRecorderTest {
         recorder.record("", 0L);
 
         verify(mapper).updatePost(any(Post.class));
+    }
+
+    @DisplayName("기록된 모든 html을 읽어온다")
+    @Test
+    public void read_all_raw_html() {
+        PostMapper mapper = mock(PostMapper.class);
+        PostRecorder recorder = new PostRecorder(mapper);
+
+        List<Post> posts = List.of(
+            Post.of("blogUrl1", 0L),
+            Post.of("blogUrl2", 1L)
+        );
+        when(mapper.selectAll()).thenReturn(
+            posts
+        );
+
+        Assertions.assertThat(recorder.readAllRawHtml())
+            .isEqualTo(
+                posts.stream()
+                    .map(p -> p.getRawHtml())
+                    .toList()
+            );
+
+        verify(mapper).selectAll();
     }
 }


### PR DESCRIPTION
- db에 저장한 링크 목록으로 인덱스 페이지를 만든다
  - 기존 구현 방식처럼 메모리 안에 링크 목록을 저장하면 재시도해서 얻은 결과를 정렬하기 어렵다
  - 링크 목록을 db에 기록해서, 재시도 기능 추가 후 인덱스 페이지 생성 시 내용이 연월별로 정렬할 수 있도록 한다
  - 변경 후 관련된 기존 구현의 반환 타입은 더 이상 쓰지 않으므로 void로 바꾼다

- 인수 테스트 정리한다
  - 같은 내용을 확인하는 테스트 지운다
  - 직접 메서드 호출하는 대신, WebArchiveScheduler에 정의된
    인터페이스를 호출하도록 고친다
  - 파일에서 가져오던 인수테스트 요청 입력값을 테스트 메서드 내에서 선언하도록 바꾼다

- 테스트 시 호출하는 sql문을 확인할 수 있도록 로그 설정한다
