### PR TITLE
실패한 요청이 있다면 해당 요청의 연월 쌍 목록을 가져와서 다시 요청한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
@@ -4,6 +4,8 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
 
+import java.util.List;
+
 @Mapper
 public interface WebArchiveReportMapper {
 
@@ -12,4 +14,6 @@ public interface WebArchiveReportMapper {
     ArchivedPageUrlReport selectReportByYearMonth(@Param("year") String year, @Param("month") String month);
 
     void updateReport(ArchivedPageUrlReport report);
+
+    List<ArchivedPageUrlReport> selectByPageExists(Boolean pageExists);
 }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -33,6 +33,11 @@ public class WebArchiveScheduler {
         bulkRequestSender.sendAll(yearMonths, archivePageService);
     }
 
+    public void doRetry() {
+        List<String> yearMonths = archivePageService.findFailedRequests();
+        bulkRequestSender.sendAll(yearMonths, archivePageService);
+    }
+
     List<String> readIndexContent() {
         return archivePageService.readIndexContent();
     }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -24,6 +24,7 @@ public class WebArchiveScheduler {
     @Scheduled(cron = "0 0 * * * *")
     public void scheduleSend() {
         doSend();
+        doRetry();
         List<String> pageLinkList = readIndexContent();
         doGenerate(pageLinkList);
     }

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -46,6 +46,11 @@ public class AgileStoryArchivePageService implements ArchivePageService {
     }
 
     @Override
+    public List<String> findFailedRequests() {
+        return List.of();
+    }
+
+    @Override
     public List<String> readIndexContent() {
         return postRecorder.readAllRawHtml();
     }

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -47,7 +47,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
 
     @Override
     public List<String> findFailedRequests() {
-        return List.of();
+        return reporter.readAllFailedRequestInput();
     }
 
     @Override

--- a/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
@@ -5,6 +5,8 @@ import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class ApiCallReporter {
 
@@ -34,5 +36,9 @@ public class ApiCallReporter {
         );
 
         return report.getPageExists() == Boolean.TRUE;
+    }
+
+    List<String> readAllFailedRequestInput() {
+        return null;
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ApiCallReporter.java
@@ -39,6 +39,9 @@ public class ApiCallReporter {
     }
 
     List<String> readAllFailedRequestInput() {
-        return null;
+        return reportMapper.selectByPageExists(Boolean.FALSE)
+            .stream()
+            .map(report -> report.getYear() + "/" + report.getMonth())
+            .toList();
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -8,5 +8,7 @@ public interface ArchivePageService {
 
     String findBlogPageLink(final CheckPostArchivedDto dto);
 
+    List<String> findFailedRequests();
+
     List<String> readIndexContent();
 }

--- a/src/main/resources/mapper/WebArchiveReportMapper.xml
+++ b/src/main/resources/mapper/WebArchiveReportMapper.xml
@@ -34,4 +34,13 @@
     WHERE `year` = #{year}
       AND `month` = #{month}
   </update>
+
+  <select id="selectByPageExists" resultType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+    SELECT year,
+           month,
+           page_exists
+    FROM post_list_page_status
+    WHERE page_exists = #{pageExists}
+      AND deleted_at IS NULL
+  </select>
 </mapper>

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -273,8 +273,10 @@ public class AcceptanceTest {
             scheduler.doRetry();
 
             fakeWebArchiveServer.hasReceivedMultipleRequests(
-                passRequests.size() + failRequests.size() * 2, // 비정상 응답받은 경우는 재시도한다
-                passRequests.size() // 재시도한 요청은 또 다시 실패한다
+                // 접근 url을 가져오는 요청 중 비정상 응답받은 경우는 재시도한다
+                passRequests.size() + failRequests.size() * 2,
+                // 블로그 목록 페이지를 가져오는 요청 중 재시도한 요청은 또 다시 실패한다
+                passRequests.size()
             );
 
             fakeWebArchiveServer.stop();

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -14,7 +14,6 @@ import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.ArchivePageController;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -233,7 +232,6 @@ public class AcceptanceTest {
             fakeWebArchiveServer.stop();
         }
 
-        @Disabled
         @DisplayName("실패한 요청을 모아서 재시도한다")
         @Test
         public void retry_failed_requests() {
@@ -272,8 +270,11 @@ public class AcceptanceTest {
             fakeWebArchiveServer.start();
 
             scheduler.doSend();
+            scheduler.doRetry();
+
             fakeWebArchiveServer.hasReceivedMultipleRequests(
-                passRequests.size() + failRequests.size() * 2 // 비정상 응답받은 경우는 재시도한다
+                passRequests.size() + failRequests.size() * 2, // 비정상 응답받은 경우는 재시도한다
+                passRequests.size() // 재시도한 요청은 또 다시 실패한다
             );
 
             fakeWebArchiveServer.stop();

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -117,7 +117,12 @@ public class FakeWebArchiveServer {
 
     public void respondItHasNoArchivedPageFor(String year, String month) {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
-            .withQueryParam("url", matching("http[s]?://agile.egloos.com/archives/[12][0-9]{3}/[0-9]{2}"))
+            .withQueryParam("url", matching(
+                String.format("http[s]?://agile.egloos.com/archives/%s/%s",
+                    year,
+                    month
+                )
+            ))
             .withQueryParam("timestamp", matching("[0-9]{8}"))
             .willReturn(aResponse().withStatus(200).withBody(
                 String.format("""
@@ -136,11 +141,24 @@ public class FakeWebArchiveServer {
     }
 
     public void hasReceivedMultipleRequests(int requestCount) {
+        hasReceivedMultipleAccessUrlRequests(requestCount);
+        hasReceivedMultiplePostListPageRequests(requestCount);
+    }
+
+    public void hasReceivedMultipleRequests(int accessUrlReqCnt, int listPageReqCnt) {
+        hasReceivedMultipleAccessUrlRequests(accessUrlReqCnt);
+        hasReceivedMultiplePostListPageRequests(listPageReqCnt);
+    }
+
+    public void hasReceivedMultipleAccessUrlRequests(int requestCount) {
         instance.verify(requestCount, getRequestedFor(urlPathTemplate("/wayback/available"))
             .withQueryParam("url",
                 matching("http[s]?://agile.egloos.com/archives/[12][0-9]{3}/[01][0-9]"))
             .withQueryParam("timestamp", matching("[0-9]{8}"))
         );
+    }
+
+    public void hasReceivedMultiplePostListPageRequests(int requestCount) {
         instance.verify(requestCount,
             getRequestedFor(urlPathTemplate("/web/{timestamp}/archives/{year}/{month}"))
                 .withPathParam("timestamp", matching("[0-9]{14}"))

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -64,4 +64,22 @@ class WebArchiveSchedulerTest {
 
         verify(service).readIndexContent();
     }
+
+    @DisplayName("실패한 요청에 대해 재시도한다")
+    @Test
+    public void retry_failed_requests() {
+        BulkRequestSender sender = mock(BulkRequestSender.class);
+        ArchivePageService service = mock(ArchivePageService.class);
+
+        doNothing().when(sender).sendAll(any(), any(ArchivePageService.class));
+
+        WebArchiveScheduler scheduler = new WebArchiveScheduler(
+            sender, service, null
+        );
+
+        scheduler.doRetry();
+
+        verify(service).findFailedRequests();
+        verify(sender).sendAll(any(), any(ArchivePageService.class));
+    }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ApiCallReporterTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 class ApiCallReporterTest {
 
@@ -52,5 +53,23 @@ class ApiCallReporterTest {
 
         verify(mapper).selectReportByYearMonth(any(), any());
         verify(mapper).updateReport(any(ArchivedPageUrlReport.class));
+    }
+
+    @DisplayName("실패한 요청 정보를 db로부터 읽어온다")
+    @Test
+    public void read_all_failed_request_info_from_db() {
+        WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
+        ApiCallReporter reporter = new ApiCallReporter(mapper);
+        List<ArchivedPageUrlReport> failRequestReports = List.of(
+            new ArchivedPageUrlReport("2020", "05", Boolean.FALSE, LocalDateTime.now()),
+            new ArchivedPageUrlReport("2021", "03", Boolean.FALSE, LocalDateTime.now())
+        );
+
+        when(mapper.selectByPageExists(any())).thenReturn(failRequestReports);
+
+        Assertions.assertThat(reporter.readAllFailedRequestInput())
+            .isEqualTo(List.of("2020/05", "2021/03"));
+
+        verify(mapper).selectByPageExists(any());
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -141,4 +141,19 @@ class ArchivePageServiceTest {
             """));
     }
 
+    @DisplayName("실패한 요청 정보를 db로부터 읽어온다")
+    @Test
+    public void read_all_failed_request_info_from_db() {
+        ApiCallReporter reporter = mock(ApiCallReporter.class);
+        AgileStoryArchivePageService service = new AgileStoryArchivePageService(
+            mock(WebArchiveApiCaller.class),
+            reporter,
+            mock(PostListPageRecorder.class),
+            mock(PostRecorder.class)
+        );
+
+        service.findFailedRequests();
+
+        verify(reporter).readAllFailedRequestInput();
+    }
 }


### PR DESCRIPTION
- 실패한 요청이 있다면 스케쥴러가 재시도하도록 한다
  - post_list_page_status 테이블에 접근 url 받아오기 실패로 기록된 요청의 연월 쌍 목록을 가져와서 재시도

- 인수 테스트 고친다
  - 재시도 시 보내는 요청은 접근 url 요청과 블로그 목록 페이지 요청 두 가지다
  - 접근 url 재요청 시, FakeWebArchiveServer가 접근 url 없음으로 응답하기 때문에, 서버는 블로그 목록 페이지
  요청을 보내지 않는다
  - 따라서 FakeWebArchiveServer가 요청을 받았는지 검증할 때 쓰는 hasReceivedMultipleRequests()가
  두 가지 요청의 갯수를 다르게 설정해야 하는데, 기존 구현에선 그럴 수 없어서 인수 테스트가 통과하지 않았다. 
  - 이를 해결하기 위해 hasReceivedMultipleRequests()를 수정해서 두 요청의 호출 횟수를 각각 검증할 수 있도록 했다
