### PR TITLE
브랜치명 정책을 변경한다

### DIFF
--- a/hooks/lib/branch_name_checker.rb
+++ b/hooks/lib/branch_name_checker.rb
@@ -2,13 +2,13 @@ require_relative './hook_report'
 
 class BranchNameChecker
   def check(now_branch_nm)
-    branch_nm_convention = /^issue-[1-9][0-9]*\/\w{1}(\w|-)*/
+    branch_nm_convention = /^(issue-[1-9][0-9]*|refactor)\/\w{1}(\w|-)*/
 
     if now_branch_nm.match(branch_nm_convention).nil?
       HookReport.new(
         'FAIL',
         ['branch name does not follow the convention!',
-         'it should match "issue-80/blah-blah"']
+         'it should match either "issue-80/blah-blah" or "refactor/blah-blah"']
       )
     else
       HookReport.new(


### PR DESCRIPTION
 - 코드 정리만을 위한 브랜치인 경우, 이슈를 할당하지 않고 refactor/xxx-yyy 와 같은 브랜치명을 쓸 수 있도록 허용한다