### PR TITLE
코드 정리한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/dao/ArchiveStatusMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/ArchiveStatusMapper.java
@@ -7,7 +7,7 @@ import org.gsh.genidxpage.entity.ArchiveStatus;
 import java.util.List;
 
 @Mapper
-public interface WebArchiveReportMapper {
+public interface ArchiveStatusMapper {
 
     Long insertReport(ArchiveStatus report);
 

--- a/src/main/java/org/gsh/genidxpage/dao/ArchiveStatusMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/ArchiveStatusMapper.java
@@ -9,11 +9,11 @@ import java.util.List;
 @Mapper
 public interface ArchiveStatusMapper {
 
-    Long insertReport(ArchiveStatus report);
+    Long insert(ArchiveStatus report);
 
-    ArchiveStatus selectReportByYearMonth(@Param("year") String year, @Param("month") String month);
+    ArchiveStatus selectByYearMonth(@Param("year") String year, @Param("month") String month);
 
-    void updateReport(ArchiveStatus report);
+    void update(ArchiveStatus report);
 
     List<ArchiveStatus> selectByPageExists(Boolean pageExists);
 }

--- a/src/main/java/org/gsh/genidxpage/dao/PostListPageMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostListPageMapper.java
@@ -7,9 +7,9 @@ import org.gsh.genidxpage.entity.PostListPage;
 @Mapper
 public interface PostListPageMapper {
 
-    Long insertPostListPage(PostListPage postListPage);
+    Long insert(PostListPage postListPage);
 
-    PostListPage selectPostListPageByYearMonth(@Param("year") String year, @Param("month") String month);
+    PostListPage selectByYearMonth(@Param("year") String year, @Param("month") String month);
 
-    Long updatePostListPage(PostListPage postListPage);
+    Long update(PostListPage postListPage);
 }

--- a/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
@@ -8,11 +8,11 @@ import java.util.List;
 @Mapper
 public interface PostMapper {
 
-    Long insertPost(Post post);
+    Long insert(Post post);
 
     Post selectByParentPageId(Long parentPageId);
 
-    Long updatePost(Post post);
+    Long update(Post post);
 
     List<Post> selectAll();
 }

--- a/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/WebArchiveReportMapper.java
@@ -2,18 +2,18 @@ package org.gsh.genidxpage.dao;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
+import org.gsh.genidxpage.entity.ArchiveStatus;
 
 import java.util.List;
 
 @Mapper
 public interface WebArchiveReportMapper {
 
-    Long insertReport(ArchivedPageUrlReport report);
+    Long insertReport(ArchiveStatus report);
 
-    ArchivedPageUrlReport selectReportByYearMonth(@Param("year") String year, @Param("month") String month);
+    ArchiveStatus selectReportByYearMonth(@Param("year") String year, @Param("month") String month);
 
-    void updateReport(ArchivedPageUrlReport report);
+    void updateReport(ArchiveStatus report);
 
-    List<ArchivedPageUrlReport> selectByPageExists(Boolean pageExists);
+    List<ArchiveStatus> selectByPageExists(Boolean pageExists);
 }

--- a/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
+++ b/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
@@ -4,7 +4,7 @@ import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 
 import java.time.LocalDateTime;
 
-public class ArchivedPageUrlReport {
+public class ArchiveStatus {
 
     private Long id;
     private String year;
@@ -14,23 +14,23 @@ public class ArchivedPageUrlReport {
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
-    public ArchivedPageUrlReport() {}
+    public ArchiveStatus() {}
 
-    public ArchivedPageUrlReport(String year, String month, Boolean pageExists) {
+    public ArchiveStatus(String year, String month, Boolean pageExists) {
         this.year = year;
         this.month = month;
         this.pageExists = pageExists;
     }
 
-    public ArchivedPageUrlReport(String year, String month, Boolean pageExists, LocalDateTime createdAt) {
+    public ArchiveStatus(String year, String month, Boolean pageExists, LocalDateTime createdAt) {
         this.year = year;
         this.month = month;
         this.pageExists = pageExists;
         this.createdAt = createdAt;
     }
 
-    public static ArchivedPageUrlReport from(CheckPostArchivedDto dto, Boolean pageExists) {
-        return new ArchivedPageUrlReport(
+    public static ArchiveStatus from(CheckPostArchivedDto dto, Boolean pageExists) {
+        return new ArchiveStatus(
             dto.getYear(),
             dto.getMonth(),
             pageExists,

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -16,12 +16,12 @@ import java.util.List;
 public class AgileStoryArchivePageService implements ArchivePageService {
 
     private final WebArchiveApiCaller webArchiveApiCaller;
-    private final ApiCallReporter reporter;
+    private final ArchiveStatusReporter reporter;
     private final PostListPageRecorder listPageRecorder;
     private final PostRecorder postRecorder;
 
     public AgileStoryArchivePageService(WebArchiveApiCaller webArchiveApiCaller,
-        ApiCallReporter reporter, PostListPageRecorder listPageRecorder, PostRecorder postRecorder) {
+        ArchiveStatusReporter reporter, PostListPageRecorder listPageRecorder, PostRecorder postRecorder) {
         this.webArchiveApiCaller = webArchiveApiCaller;
         this.reporter = reporter;
         this.listPageRecorder = listPageRecorder;

--- a/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
@@ -1,6 +1,6 @@
 package org.gsh.genidxpage.service;
 
-import org.gsh.genidxpage.dao.WebArchiveReportMapper;
+import org.gsh.genidxpage.dao.ArchiveStatusMapper;
 import org.gsh.genidxpage.entity.ArchiveStatus;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.stereotype.Component;
@@ -10,9 +10,9 @@ import java.util.List;
 @Component
 public class ArchiveStatusReporter {
 
-    private final WebArchiveReportMapper reportMapper;
+    private final ArchiveStatusMapper reportMapper;
 
-    public ArchiveStatusReporter(WebArchiveReportMapper reportMapper) {
+    public ArchiveStatusReporter(ArchiveStatusMapper reportMapper) {
         this.reportMapper = reportMapper;
     }
 

--- a/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
@@ -1,7 +1,7 @@
 package org.gsh.genidxpage.service;
 
 import org.gsh.genidxpage.dao.WebArchiveReportMapper;
-import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
+import org.gsh.genidxpage.entity.ArchiveStatus;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.springframework.stereotype.Component;
 
@@ -17,20 +17,20 @@ public class ArchiveStatusReporter {
     }
 
     void reportArchivedPageSearch(final CheckPostArchivedDto dto, final Boolean pageExists) {
-        ArchivedPageUrlReport hasReport = reportMapper.selectReportByYearMonth(dto.getYear(),
+        ArchiveStatus hasReport = reportMapper.selectReportByYearMonth(dto.getYear(),
             dto.getMonth());
 
         if (hasReport != null) {
-            reportMapper.updateReport(ArchivedPageUrlReport.from(dto, pageExists));
+            reportMapper.updateReport(ArchiveStatus.from(dto, pageExists));
             return;
         }
 
-        ArchivedPageUrlReport report = ArchivedPageUrlReport.from(dto, pageExists);
+        ArchiveStatus report = ArchiveStatus.from(dto, pageExists);
         reportMapper.insertReport(report);
     }
 
     public boolean hasArchivedPage(final CheckPostArchivedDto dto) {
-        ArchivedPageUrlReport report = reportMapper.selectReportByYearMonth(
+        ArchiveStatus report = reportMapper.selectReportByYearMonth(
             dto.getYear(),
             dto.getMonth()
         );

--- a/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
@@ -17,20 +17,20 @@ public class ArchiveStatusReporter {
     }
 
     void reportArchivedPageSearch(final CheckPostArchivedDto dto, final Boolean pageExists) {
-        ArchiveStatus hasReport = reportMapper.selectReportByYearMonth(dto.getYear(),
+        ArchiveStatus hasReport = reportMapper.selectByYearMonth(dto.getYear(),
             dto.getMonth());
 
         if (hasReport != null) {
-            reportMapper.updateReport(ArchiveStatus.from(dto, pageExists));
+            reportMapper.update(ArchiveStatus.from(dto, pageExists));
             return;
         }
 
         ArchiveStatus report = ArchiveStatus.from(dto, pageExists);
-        reportMapper.insertReport(report);
+        reportMapper.insert(report);
     }
 
     public boolean hasArchivedPage(final CheckPostArchivedDto dto) {
-        ArchiveStatus report = reportMapper.selectReportByYearMonth(
+        ArchiveStatus report = reportMapper.selectByYearMonth(
             dto.getYear(),
             dto.getMonth()
         );

--- a/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
@@ -8,11 +8,11 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class ApiCallReporter {
+public class ArchiveStatusReporter {
 
     private final WebArchiveReportMapper reportMapper;
 
-    public ApiCallReporter(WebArchiveReportMapper reportMapper) {
+    public ArchiveStatusReporter(WebArchiveReportMapper reportMapper) {
         this.reportMapper = reportMapper;
     }
 

--- a/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostListPageRecorder.java
@@ -18,7 +18,7 @@ public class PostListPageRecorder {
     }
 
     Long record(final CheckPostArchivedDto dto, final ArchivedPageInfo archivedPageInfo) {
-        PostListPage hasPostListPage = mapper.selectPostListPageByYearMonth(
+        PostListPage hasPostListPage = mapper.selectByYearMonth(
             dto.getYear(),
             dto.getMonth()
         );
@@ -27,13 +27,13 @@ public class PostListPageRecorder {
             log.info(
                 "updating access url with id of " + hasPostListPage.getId() + " with content of "
                     + archivedPageInfo.accessibleUrl());
-            mapper.updatePostListPage(PostListPage.of(dto, archivedPageInfo));
+            mapper.update(PostListPage.of(dto, archivedPageInfo));
             return hasPostListPage.getId();
         }
 
         log.info("inserting access url of " + archivedPageInfo.accessibleUrl());
         PostListPage postListPage = PostListPage.of(dto, archivedPageInfo);
-        mapper.insertPostListPage(postListPage);
+        mapper.insert(postListPage);
         return postListPage.getId();
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -21,11 +21,11 @@ public class PostRecorder {
     public void record(String rawHtml, Long listPageId) {
         Post hasPost = mapper.selectByParentPageId(listPageId);
         if (hasPost != null) {
-            mapper.updatePost(Post.of(rawHtml, listPageId));
+            mapper.update(Post.of(rawHtml, listPageId));
             return;
         }
 
-        mapper.insertPost(Post.of(rawHtml, listPageId));
+        mapper.insert(Post.of(rawHtml, listPageId));
     }
 
     public List<String> readAllRawHtml() {

--- a/src/main/resources/mapper/ArchiveStatusMapper.xml
+++ b/src/main/resources/mapper/ArchiveStatusMapper.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.gsh.genidxpage.dao.ArchiveStatusMapper">
-  <insert id="insertReport" useGeneratedKeys="true" keyProperty="id"
+  <insert id="insert" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.ArchiveStatus">
 
     INSERT INTO post_list_page_status (year,
@@ -16,7 +16,7 @@
             #{createdAt})
   </insert>
 
-  <select id="selectReportByYearMonth" resultType="org.gsh.genidxpage.entity.ArchiveStatus">
+  <select id="selectByYearMonth" resultType="org.gsh.genidxpage.entity.ArchiveStatus">
     SELECT `year`,
            `month`,
            page_exists
@@ -26,7 +26,7 @@
       AND deleted_at IS NULL
   </select>
 
-  <update id="updateReport" useGeneratedKeys="true" keyProperty="id"
+  <update id="update" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.ArchiveStatus">
     UPDATE post_list_page_status
     SET page_exists = #{pageExists},

--- a/src/main/resources/mapper/ArchiveStatusMapper.xml
+++ b/src/main/resources/mapper/ArchiveStatusMapper.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="org.gsh.genidxpage.dao.WebArchiveReportMapper">
+<mapper namespace="org.gsh.genidxpage.dao.ArchiveStatusMapper">
   <insert id="insertReport" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.ArchiveStatus">
 

--- a/src/main/resources/mapper/PostListPageMapper.xml
+++ b/src/main/resources/mapper/PostListPageMapper.xml
@@ -4,7 +4,7 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.gsh.genidxpage.dao.PostListPageMapper">
-  <insert id="insertPostListPage" useGeneratedKeys="true" keyProperty="id"
+  <insert id="insert" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.PostListPage">
 
     INSERT INTO post_list_page (year,
@@ -17,7 +17,7 @@
             #{createdAt})
   </insert>
 
-  <select id="selectPostListPageByYearMonth" resultType="org.gsh.genidxpage.entity.PostListPage">
+  <select id="selectByYearMonth" resultType="org.gsh.genidxpage.entity.PostListPage">
     SELECT id,
            year,
            month,
@@ -28,7 +28,7 @@
       AND deleted_at IS NULL
   </select>
 
-  <update id="updatePostListPage" useGeneratedKeys="true" keyProperty="id"
+  <update id="update" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.PostListPage">
     UPDATE post_list_page
     SET url        = #{url},

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -4,7 +4,7 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.gsh.genidxpage.dao.PostMapper">
-  <insert id="insertPost" useGeneratedKeys="true" keyProperty="id"
+  <insert id="insert" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.Post">
     INSERT INTO post (parent_page_id,
                       raw_html,
@@ -23,7 +23,7 @@
       AND deleted_at IS NULL
   </select>
 
-  <update id="updatePost" useGeneratedKeys="true" keyProperty="id"
+  <update id="update" useGeneratedKeys="true" keyProperty="id"
     parameterType="org.gsh.genidxpage.entity.Post">
     UPDATE post
     SET raw_html = #{rawHtml},

--- a/src/main/resources/mapper/WebArchiveReportMapper.xml
+++ b/src/main/resources/mapper/WebArchiveReportMapper.xml
@@ -4,7 +4,7 @@
 
 <mapper namespace="org.gsh.genidxpage.dao.WebArchiveReportMapper">
   <insert id="insertReport" useGeneratedKeys="true" keyProperty="id"
-    parameterType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+    parameterType="org.gsh.genidxpage.entity.ArchiveStatus">
 
     INSERT INTO post_list_page_status (year,
                           month,
@@ -16,7 +16,7 @@
             #{createdAt})
   </insert>
 
-  <select id="selectReportByYearMonth" resultType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+  <select id="selectReportByYearMonth" resultType="org.gsh.genidxpage.entity.ArchiveStatus">
     SELECT `year`,
            `month`,
            page_exists
@@ -27,7 +27,7 @@
   </select>
 
   <update id="updateReport" useGeneratedKeys="true" keyProperty="id"
-    parameterType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+    parameterType="org.gsh.genidxpage.entity.ArchiveStatus">
     UPDATE post_list_page_status
     SET page_exists = #{pageExists},
         updated_at  = #{updatedAt}
@@ -35,7 +35,7 @@
       AND `month` = #{month}
   </update>
 
-  <select id="selectByPageExists" resultType="org.gsh.genidxpage.entity.ArchivedPageUrlReport">
+  <select id="selectByPageExists" resultType="org.gsh.genidxpage.entity.ArchiveStatus">
     SELECT year,
            month,
            page_exists

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -5,7 +5,7 @@ import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
 import org.gsh.genidxpage.scheduler.BulkRequestSender;
 import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
-import org.gsh.genidxpage.service.ApiCallReporter;
+import org.gsh.genidxpage.service.ArchiveStatusReporter;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.gsh.genidxpage.service.PostListPageRecorder;
@@ -36,7 +36,7 @@ public class AcceptanceTest {
 
     private ArchivePageController archivePageController;
     @Autowired
-    private ApiCallReporter reporter;
+    private ArchiveStatusReporter reporter;
     @Autowired
     private PostListPageRecorder listPageRecorder;
     @Autowired

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -31,7 +31,7 @@ class ArchivePageServiceTest {
         when(caller.findArchivedPageInfo(any())).thenReturn(
             noArchivedPageInfo
         );
-        ApiCallReporter reporter = mock(ApiCallReporter.class);
+        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter, null, null);
 
@@ -56,7 +56,7 @@ class ArchivePageServiceTest {
             archivedPageInfo
         );
         when(caller.isArchived(any())).thenReturn(true);
-        ApiCallReporter reporter = mock(ApiCallReporter.class);
+        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter,
             mock(PostListPageRecorder.class), null);
@@ -74,7 +74,7 @@ class ArchivePageServiceTest {
 
         PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller,
-            mock(ApiCallReporter.class), listPageRecorder, mock(PostRecorder.class));
+            mock(ArchiveStatusReporter.class), listPageRecorder, mock(PostRecorder.class));
 
         CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
         service.findBlogPageLink(dto);
@@ -91,7 +91,7 @@ class ArchivePageServiceTest {
 
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(
             caller,
-            mock(ApiCallReporter.class),
+            mock(ArchiveStatusReporter.class),
             mock(PostListPageRecorder.class),
             postRecorder
         );
@@ -111,7 +111,7 @@ class ArchivePageServiceTest {
 
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(
             caller,
-            mock(ApiCallReporter.class),
+            mock(ArchiveStatusReporter.class),
             mock(PostListPageRecorder.class),
             postRecorder
         );
@@ -144,7 +144,7 @@ class ArchivePageServiceTest {
     @DisplayName("실패한 요청 정보를 db로부터 읽어온다")
     @Test
     public void read_all_failed_request_info_from_db() {
-        ApiCallReporter reporter = mock(ApiCallReporter.class);
+        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
         AgileStoryArchivePageService service = new AgileStoryArchivePageService(
             mock(WebArchiveApiCaller.class),
             reporter,

--- a/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.dao.WebArchiveReportMapper;
-import org.gsh.genidxpage.entity.ArchivedPageUrlReport;
+import org.gsh.genidxpage.entity.ArchiveStatus;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ class ArchiveStatusReporterTest {
     public void check_url_exists_in_web_archive_for_given_year_month() {
         WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
         ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
-        ArchivedPageUrlReport report = new ArchivedPageUrlReport(
+        ArchiveStatus report = new ArchiveStatus(
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
         );
 
@@ -40,7 +40,7 @@ class ArchiveStatusReporterTest {
     public void only_update_status_when_page_status_already_inserted() {
         WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
         ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
-        ArchivedPageUrlReport report = new ArchivedPageUrlReport(
+        ArchiveStatus report = new ArchiveStatus(
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
         );
 
@@ -52,7 +52,7 @@ class ArchiveStatusReporterTest {
         reporter.reportArchivedPageSearch(dto, Boolean.TRUE);
 
         verify(mapper).selectReportByYearMonth(any(), any());
-        verify(mapper).updateReport(any(ArchivedPageUrlReport.class));
+        verify(mapper).updateReport(any(ArchiveStatus.class));
     }
 
     @DisplayName("실패한 요청 정보를 db로부터 읽어온다")
@@ -60,9 +60,9 @@ class ArchiveStatusReporterTest {
     public void read_all_failed_request_info_from_db() {
         WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
         ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
-        List<ArchivedPageUrlReport> failRequestReports = List.of(
-            new ArchivedPageUrlReport("2020", "05", Boolean.FALSE, LocalDateTime.now()),
-            new ArchivedPageUrlReport("2021", "03", Boolean.FALSE, LocalDateTime.now())
+        List<ArchiveStatus> failRequestReports = List.of(
+            new ArchiveStatus("2020", "05", Boolean.FALSE, LocalDateTime.now()),
+            new ArchiveStatus("2021", "03", Boolean.FALSE, LocalDateTime.now())
         );
 
         when(mapper.selectByPageExists(any())).thenReturn(failRequestReports);

--- a/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
@@ -16,13 +16,13 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.List;
 
-class ApiCallReporterTest {
+class ArchiveStatusReporterTest {
 
     @DisplayName("web archive로부터 url을 받아온 연월인지 확인할 수 있다")
     @Test
     public void check_url_exists_in_web_archive_for_given_year_month() {
         WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
-        ApiCallReporter reporter = new ApiCallReporter(mapper);
+        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
         ArchivedPageUrlReport report = new ArchivedPageUrlReport(
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
         );
@@ -39,7 +39,7 @@ class ApiCallReporterTest {
     @Test
     public void only_update_status_when_page_status_already_inserted() {
         WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
-        ApiCallReporter reporter = new ApiCallReporter(mapper);
+        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
         ArchivedPageUrlReport report = new ArchivedPageUrlReport(
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
         );
@@ -59,7 +59,7 @@ class ApiCallReporterTest {
     @Test
     public void read_all_failed_request_info_from_db() {
         WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
-        ApiCallReporter reporter = new ApiCallReporter(mapper);
+        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
         List<ArchivedPageUrlReport> failRequestReports = List.of(
             new ArchivedPageUrlReport("2020", "05", Boolean.FALSE, LocalDateTime.now()),
             new ArchivedPageUrlReport("2021", "03", Boolean.FALSE, LocalDateTime.now())

--- a/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
-import org.gsh.genidxpage.dao.WebArchiveReportMapper;
+import org.gsh.genidxpage.dao.ArchiveStatusMapper;
 import org.gsh.genidxpage.entity.ArchiveStatus;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +21,7 @@ class ArchiveStatusReporterTest {
     @DisplayName("web archive로부터 url을 받아온 연월인지 확인할 수 있다")
     @Test
     public void check_url_exists_in_web_archive_for_given_year_month() {
-        WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
+        ArchiveStatusMapper mapper = mock(ArchiveStatusMapper.class);
         ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
         ArchiveStatus report = new ArchiveStatus(
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
@@ -38,7 +38,7 @@ class ArchiveStatusReporterTest {
     @DisplayName("이미 db에 기록된 경우, 새로운 행을 추가하지 않는다")
     @Test
     public void only_update_status_when_page_status_already_inserted() {
-        WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
+        ArchiveStatusMapper mapper = mock(ArchiveStatusMapper.class);
         ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
         ArchiveStatus report = new ArchiveStatus(
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
@@ -58,7 +58,7 @@ class ArchiveStatusReporterTest {
     @DisplayName("실패한 요청 정보를 db로부터 읽어온다")
     @Test
     public void read_all_failed_request_info_from_db() {
-        WebArchiveReportMapper mapper = mock(WebArchiveReportMapper.class);
+        ArchiveStatusMapper mapper = mock(ArchiveStatusMapper.class);
         ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
         List<ArchiveStatus> failRequestReports = List.of(
             new ArchiveStatus("2020", "05", Boolean.FALSE, LocalDateTime.now()),

--- a/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
@@ -27,7 +27,7 @@ class ArchiveStatusReporterTest {
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
         );
 
-        when(mapper.selectReportByYearMonth(any(), any())).thenReturn(report);
+        when(mapper.selectByYearMonth(any(), any())).thenReturn(report);
 
         boolean hasArchivedPage = reporter.hasArchivedPage(
             new CheckPostArchivedDto("2021", "3")
@@ -44,15 +44,15 @@ class ArchiveStatusReporterTest {
             "2021", "3", Boolean.TRUE, LocalDateTime.now()
         );
 
-        when(mapper.selectReportByYearMonth(any(), any())).thenReturn(
+        when(mapper.selectByYearMonth(any(), any())).thenReturn(
             report);
-        doNothing().when(mapper).updateReport(report);
+        doNothing().when(mapper).update(report);
 
         CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
         reporter.reportArchivedPageSearch(dto, Boolean.TRUE);
 
-        verify(mapper).selectReportByYearMonth(any(), any());
-        verify(mapper).updateReport(any(ArchiveStatus.class));
+        verify(mapper).selectByYearMonth(any(), any());
+        verify(mapper).update(any(ArchiveStatus.class));
     }
 
     @DisplayName("실패한 요청 정보를 db로부터 읽어온다")

--- a/src/test/java/org/gsh/genidxpage/service/PostListPageRecorderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostListPageRecorderTest.java
@@ -29,7 +29,7 @@ class PostListPageRecorderTest {
             .build();
         recorder.record(dto, archivedPageInfo);
 
-        verify(mapper).insertPostListPage(any(PostListPage.class));
+        verify(mapper).insert(any(PostListPage.class));
     }
 
     @DisplayName("이미 등록된 연월의 url이면 업데이트만 한다")
@@ -44,7 +44,7 @@ class PostListPageRecorderTest {
             "http://localhost:8080/web/20230614220926/archives/2021/03",
             LocalDateTime.now()
         );
-        when(mapper.selectPostListPageByYearMonth(any(), any())).thenReturn(postListPage);
+        when(mapper.selectByYearMonth(any(), any())).thenReturn(postListPage);
 
         CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
         ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
@@ -52,6 +52,6 @@ class PostListPageRecorderTest {
             .build();
         recorder.record(dto, archivedPageInfo);
 
-        verify(mapper).updatePostListPage(any(PostListPage.class));
+        verify(mapper).update(any(PostListPage.class));
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
@@ -23,7 +23,7 @@ class PostRecorderTest {
 
         recorder.record("", 0L);
 
-        verify(mapper).insertPost(any(Post.class));
+        verify(mapper).insert(any(Post.class));
     }
 
     @DisplayName("db에 부모 페이지 아이디에 연결된 html이 이미 기록되어 있으면, 업데이트한다")
@@ -35,7 +35,7 @@ class PostRecorderTest {
         when(mapper.selectByParentPageId(any())).thenReturn(Post.of("", 0L));
         recorder.record("", 0L);
 
-        verify(mapper).updatePost(any(Post.class));
+        verify(mapper).update(any(Post.class));
     }
 
     @DisplayName("기록된 모든 html을 읽어온다")


### PR DESCRIPTION
- 클래스명 정리한다
  - ApiCallReporter -> ArchiveStatusReporter
  - ArchivedPageUrlReport -> ArchiveStatus
  - WebArchiveReportMapper -> ArchiveStatusMapper

- Mapper에 정의한 메서드명에서 엔티티명을 지워서 간단하게 만든다
  - ArchiveStatusMapper 메서드명에서 report를 제외한다
  - PostListPageMapper 메서드명에서 PostListPage를 제외한다
  - PostMapper 메서드명에서 post를 제외한다