### PR TITLE
인덱스 파일 내용 형식을 정리한다

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -300,7 +300,7 @@
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>
-            <property name="allowedAbbreviationLength" value="0"/>
+            <property name="allowedAbbreviationLength" value="3"/>
             <property name="tokens"
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,

--- a/src/main/java/org/gsh/genidxpage/dao/IndexContentMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/IndexContentMapper.java
@@ -1,0 +1,12 @@
+package org.gsh.genidxpage.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.gsh.genidxpage.vo.IndexContent;
+
+import java.util.List;
+
+@Mapper
+public interface IndexContentMapper {
+
+    List<IndexContent> selectAll();
+}

--- a/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostMapper.java
@@ -3,8 +3,6 @@ package org.gsh.genidxpage.dao;
 import org.apache.ibatis.annotations.Mapper;
 import org.gsh.genidxpage.entity.Post;
 
-import java.util.List;
-
 @Mapper
 public interface PostMapper {
 
@@ -13,6 +11,4 @@ public interface PostMapper {
     Post selectByParentPageId(Long parentPageId);
 
     Long update(Post post);
-
-    List<Post> selectAll();
 }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -40,6 +40,7 @@ public class WebArchiveScheduler {
     }
 
     List<String> readIndexContent() {
+        indexPageGenerator.readIndexContent();
         return archivePageService.readIndexContent();
     }
 

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -40,8 +40,7 @@ public class WebArchiveScheduler {
     }
 
     List<String> readIndexContent() {
-        indexPageGenerator.readIndexContent();
-        return archivePageService.readIndexContent();
+        return indexPageGenerator.readIndexContent();
     }
 
     void doGenerate(List<String> pageLinkList) {

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -50,11 +50,6 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         return reporter.readAllFailedRequestInput();
     }
 
-    @Override
-    public List<String> readIndexContent() {
-        return postRecorder.readAllRawHtml();
-    }
-
     ArchivedPageInfo findArchivedPageInfo(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto);
 

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -9,6 +9,4 @@ public interface ArchivePageService {
     String findBlogPageLink(final CheckPostArchivedDto dto);
 
     List<String> findFailedRequests();
-
-    List<String> readIndexContent();
 }

--- a/src/main/java/org/gsh/genidxpage/service/IndexContentReader.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexContentReader.java
@@ -1,5 +1,6 @@
 package org.gsh.genidxpage.service;
 
+import org.gsh.genidxpage.dao.IndexContentMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -7,7 +8,18 @@ import java.util.List;
 @Repository
 public class IndexContentReader {
 
+    private final IndexContentMapper mapper;
+
+    public IndexContentReader(IndexContentMapper mapper) {
+        this.mapper = mapper;
+    }
+
     public List<String> readAllIndexContent() {
-        return null;
+        return mapper.selectAll()
+            .stream()
+            .map(indexContent -> {
+                return indexContent.toString();
+            })
+            .toList();
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/IndexContentReader.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexContentReader.java
@@ -1,0 +1,13 @@
+package org.gsh.genidxpage.service;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class IndexContentReader {
+
+    public List<String> readAllIndexContent() {
+        return null;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -18,9 +18,12 @@ import java.util.List;
 public class IndexPageGenerator {
 
     private final String inputPath;
+    private final IndexContentReader reader;
 
-    public IndexPageGenerator(@Value("${index-page.path}") final String inputPath) {
+    public IndexPageGenerator(@Value("${index-page.path}") final String inputPath,
+        IndexContentReader reader) {
         this.inputPath = inputPath;
+        this.reader = reader;
     }
 
     // TODO
@@ -79,6 +82,6 @@ public class IndexPageGenerator {
     }
 
     public List<String> readIndexContent() {
-        return null;
+        return reader.readAllIndexContent();
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -31,17 +31,17 @@ public class IndexPageGenerator {
     // TODO
     //  파일 관련 연산을 별도의 객체로 분리
     //  예외 발생 상황 테스트를 추가
-    public void generateIndexPage(List<String> pageLinksList) {
+    public void generateIndexPage(List<String> postLinksList) {
         StringBuilder builder = new StringBuilder();
         builder.append(generateHeader());
-        for (String pageLink : pageLinksList) {
-            String postLinkId = pageLink.split(":")[0].trim();
-            builder.append(String.format("<div class=\"post-list-id\">%s</div>", postLinkId));
+        for (String postLinks : postLinksList) {
+            String postLinksGroupId = postLinks.split(":")[0].trim();
+            builder.append(String.format("<div class=\"post-list-id\">%s</div>", postLinksGroupId));
 
-            String postLinks = Arrays.stream(pageLink.split(":")).skip(1)
+            String postLinksHtml = Arrays.stream(postLinks.split(":")).skip(1)
                 .collect(Collectors.joining(":"));
-            for (String link : postLinks.split("\n")) {
-                builder.append(link);
+            for (String postLink : postLinksHtml.split("\n")) {
+                builder.append(postLink);
                 builder.append("<br>");
                 builder.append("\n");
             }

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -77,4 +77,8 @@ public class IndexPageGenerator {
             </html>
             """;
     }
+
+    public List<String> readIndexContent() {
+        return null;
+    }
 }

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -11,7 +11,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -33,8 +35,12 @@ public class IndexPageGenerator {
         StringBuilder builder = new StringBuilder();
         builder.append(generateHeader());
         for (String pageLink : pageLinksList) {
-            String[] split = pageLink.split("\n");
-            for (String link : split) {
+            String postLinkId = pageLink.split(":")[0].trim();
+            builder.append(String.format("<div class=\"post-list-id\">%s</div>", postLinkId));
+
+            String postLinks = Arrays.stream(pageLink.split(":")).skip(1)
+                .collect(Collectors.joining(":"));
+            for (String link : postLinks.split("\n")) {
                 builder.append(link);
                 builder.append("<br>");
                 builder.append("\n");

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -58,16 +58,21 @@ public class IndexPageGenerator {
 
     private String generateHeader() {
         return """
-            <html>
-              <head>
-                <meta charset="utf-8">
-              </head>
-              <body>
+             <!DOCTYPE html>
+             <html>
+               <head>
+                 <meta charset="utf-8">
+                 <title>agile story blog index</title>
+                 <link rel="stylesheet" href="./index.css" type="text/css" media="screen" />
+               </head>
+               <body>
+                 <div class="site">
             """;
     }
 
     private String generateFooter() {
         return """
+                </div>
               </body>
             </html>
             """;

--- a/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostRecorder.java
@@ -5,9 +5,6 @@ import org.gsh.genidxpage.entity.Post;
 import org.springframework.stereotype.Repository;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Slf4j
 @Repository
 public class PostRecorder {
@@ -26,12 +23,5 @@ public class PostRecorder {
         }
 
         mapper.insert(Post.createFrom(rawHtml, listPageId));
-    }
-
-    public List<String> readAllRawHtml() {
-        return mapper.selectAll()
-            .stream()
-            .map(post -> post.getRawHtml())
-            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/gsh/genidxpage/vo/IndexContent.java
+++ b/src/main/java/org/gsh/genidxpage/vo/IndexContent.java
@@ -2,24 +2,23 @@ package org.gsh.genidxpage.vo;
 
 public class IndexContent {
 
-    private String year;
-    private String month;
+    private String postListId;
     private String rawHtml;
 
     private IndexContent() {}
 
-    IndexContent(String year, String month, String rawHtml) {
-        this.year = year;
-        this.month = month;
+    IndexContent(String postListId, String rawHtml) {
+        this.postListId = postListId;
         this.rawHtml = rawHtml;
     }
 
     public static IndexContent from(String year, String month, String rawHtml) {
-        return new IndexContent(year, month, rawHtml);
+        String postListId =  String.format("%s/%s", year, month);
+        return new IndexContent(postListId, rawHtml);
     }
 
     @Override
     public String toString() {
-        return String.format("%s/%s:%s", year, month, rawHtml);
+        return String.format("%s:%s", postListId, rawHtml);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/vo/IndexContent.java
+++ b/src/main/java/org/gsh/genidxpage/vo/IndexContent.java
@@ -1,0 +1,25 @@
+package org.gsh.genidxpage.vo;
+
+public class IndexContent {
+
+    private String year;
+    private String month;
+    private String rawHtml;
+
+    private IndexContent() {}
+
+    IndexContent(String year, String month, String rawHtml) {
+        this.year = year;
+        this.month = month;
+        this.rawHtml = rawHtml;
+    }
+
+    public static IndexContent from(String year, String month, String rawHtml) {
+        return new IndexContent(year, month, rawHtml);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s/%s:%s", year, month, rawHtml);
+    }
+}

--- a/src/main/resources/mapper/IndexContentMapper.xml
+++ b/src/main/resources/mapper/IndexContentMapper.xml
@@ -5,7 +5,7 @@
 
 <mapper namespace="org.gsh.genidxpage.dao.IndexContentMapper">
   <select id="selectAll" resultType="org.gsh.genidxpage.vo.IndexContent">
-    SELECT plp.year, plp.month, p.raw_html
+    SELECT CONCAT(plp.year, '/', plp.month) AS post_list_id, p.raw_html
     FROM post_list_page plp
       INNER JOIN post p
       ON plp.id = p.parent_page_id;

--- a/src/main/resources/mapper/IndexContentMapper.xml
+++ b/src/main/resources/mapper/IndexContentMapper.xml
@@ -8,6 +8,7 @@
     SELECT CONCAT(plp.year, '/', plp.month) AS post_list_id, p.raw_html
     FROM post_list_page plp
       INNER JOIN post p
-      ON plp.id = p.parent_page_id;
+      ON plp.id = p.parent_page_id
+    ORDER BY plp.year DESC, plp.month DESC;
   </select>
 </mapper>

--- a/src/main/resources/mapper/IndexContentMapper.xml
+++ b/src/main/resources/mapper/IndexContentMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.gsh.genidxpage.dao.IndexContentMapper">
+  <select id="selectAll" resultType="org.gsh.genidxpage.vo.IndexContent">
+    SELECT plp.year, plp.month, p.raw_html
+    FROM post_list_page plp
+      INNER JOIN post p
+      ON plp.id = p.parent_page_id;
+  </select>
+</mapper>

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -30,13 +30,4 @@
         updated_at = #{updatedAt}
     WHERE parent_page_id = #{parentPageId}
   </update>
-
-  <select id="selectAll" resultType="org.gsh.genidxpage.entity.Post">
-    SELECT parent_page_id,
-           raw_html,
-           created_at
-    FROM post
-    WHERE raw_html IS NOT NULL
-      AND deleted_at IS NULL
-  </select>
 </mapper>

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -7,6 +7,7 @@ import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
 import org.gsh.genidxpage.service.ArchiveStatusReporter;
 import org.gsh.genidxpage.service.ArchivePageService;
+import org.gsh.genidxpage.service.IndexContentReader;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.gsh.genidxpage.service.PostListPageRecorder;
 import org.gsh.genidxpage.service.PostRecorder;
@@ -41,6 +42,8 @@ public class AcceptanceTest {
     private PostListPageRecorder listPageRecorder;
     @Autowired
     private PostRecorder postRecorder;
+    @Autowired
+    private IndexContentReader reader;
 
     @Nested
     class ArchivePageControllerTest {
@@ -179,7 +182,8 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
-                bulkRequestSender, service, new IndexPageGenerator("/tmp/genidxpage/test")
+                bulkRequestSender, service,
+                new IndexPageGenerator("/tmp/genidxpage/test", reader)
             );
 
             // 요청할 모든 입력쌍을 만든다

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -52,18 +52,16 @@ class WebArchiveSchedulerTest {
     @DisplayName("db에서 인덱스 파일 생성에 쓸 블로그 링크 html을 가져온다")
     @Test
     public void read_index_content_from_db() {
-        ArchivePageService service = mock(ArchivePageService.class);
         IndexPageGenerator generator = mock(IndexPageGenerator.class);
 
         WebArchiveScheduler scheduler = new WebArchiveScheduler(
             mock(BulkRequestSender.class),
-            service,
+            mock(ArchivePageService.class),
             generator
         );
 
         scheduler.readIndexContent();
 
-        verify(service).readIndexContent();
         verify(generator).readIndexContent();
     }
 

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -53,16 +53,18 @@ class WebArchiveSchedulerTest {
     @Test
     public void read_index_content_from_db() {
         ArchivePageService service = mock(ArchivePageService.class);
+        IndexPageGenerator generator = mock(IndexPageGenerator.class);
 
         WebArchiveScheduler scheduler = new WebArchiveScheduler(
             mock(BulkRequestSender.class),
             service,
-            null
+            generator
         );
 
         scheduler.readIndexContent();
 
         verify(service).readIndexContent();
+        verify(generator).readIndexContent();
     }
 
     @DisplayName("실패한 요청에 대해 재시도한다")

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -102,25 +102,6 @@ class ArchivePageServiceTest {
         verify(postRecorder).record(any(), any());
     }
 
-    @DisplayName("기록된 블로그 링크 html 전체를 db에서 읽어온다")
-    @Test
-    public void read_all_raw_html_from_db() {
-        PostRecorder postRecorder = mock(PostRecorder.class);
-        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
-        respondsValidBlogPostPage(caller);
-
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(
-            caller,
-            mock(ArchiveStatusReporter.class),
-            mock(PostListPageRecorder.class),
-            postRecorder
-        );
-
-        service.readIndexContent();
-
-        verify(postRecorder).readAllRawHtml();
-    }
-
     private void respondsValidBlogPostPage(WebArchiveApiCaller caller) {
         ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
             .url("url")

--- a/src/test/java/org/gsh/genidxpage/service/IndexContentReaderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexContentReaderTest.java
@@ -1,0 +1,39 @@
+package org.gsh.genidxpage.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.api.Assertions;
+import org.gsh.genidxpage.dao.IndexContentMapper;
+import org.gsh.genidxpage.vo.IndexContent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class IndexContentReaderTest {
+
+    @DisplayName("기록된 모든 연월과 html을 읽어온다")
+    @Test
+    public void read_all_year_month_and_raw_html() {
+        IndexContentMapper mapper = mock(IndexContentMapper.class);
+        IndexContentReader reader = new IndexContentReader(mapper);
+
+        List<IndexContent> indexContents = List.of(
+            IndexContent.from("2021", "3", "blogUrl1"),
+            IndexContent.from("2021", "3", "blogUrl2")
+        );
+        when(mapper.selectAll()).thenReturn(
+            indexContents
+        );
+
+        reader.readAllIndexContent().stream().forEach(
+            indexContent -> Assertions.assertThat(
+                indexContent.matches("\\d{4}/\\d{2}:blog\\.*")
+            )
+        );
+
+        verify(mapper).selectAll();
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/service/IndexContentReaderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexContentReaderTest.java
@@ -30,7 +30,7 @@ class IndexContentReaderTest {
 
         reader.readAllIndexContent().stream().forEach(
             indexContent -> Assertions.assertThat(
-                indexContent.matches("\\d{4}/\\d{2}:blog\\.*")
+                indexContent.matches("\\d{4}/\\d{2}:\\.*")
             )
         );
 

--- a/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
@@ -18,8 +18,11 @@ class IndexPageGeneratorTest {
     @DisplayName("블로그 링크 목록으로 인덱스 페이지를 만들 수 있다")
     @Test
     public void generate_index_page_from_blog_link_list() throws IOException {
-
-        List<String> pageLinksList = List.of("l1\nl2", "l3", "l4");
+        List<String> pageLinksList = List.of(
+            "2021/03:<a href=\"https://x.net\">l1</a>",
+            "2020/05:<a href=\"https://x.net\">l2</a>",
+            "2020/02:<a href=\"https://x.net\">l3</a>\n<a href=\"https://x.net\">l4</a>"
+        );
         IndexPageGenerator generator = new IndexPageGenerator("/tmp/genidxpage", null);
         generator.generateIndexPage(pageLinksList);
         String fileContent = Files.readString(Path.of("/tmp/genidxpage/index.html"), StandardCharsets.UTF_8);

--- a/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
@@ -1,5 +1,8 @@
 package org.gsh.genidxpage.service;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,12 +20,26 @@ class IndexPageGeneratorTest {
     public void generate_index_page_from_blog_link_list() throws IOException {
 
         List<String> pageLinksList = List.of("l1\nl2", "l3", "l4");
-        IndexPageGenerator generator = new IndexPageGenerator("/tmp/genidxpage");
+        IndexPageGenerator generator = new IndexPageGenerator("/tmp/genidxpage", null);
         generator.generateIndexPage(pageLinksList);
         String fileContent = Files.readString(Path.of("/tmp/genidxpage/index.html"), StandardCharsets.UTF_8);
         Assertions.assertThat(fileContent).contains("l1")
             .contains("l2")
             .contains("l3")
             .contains("l4");
+    }
+
+    @DisplayName("인덱스 페이지에 쓸 내용을 db에서 읽어온다")
+    @Test
+    public void read_all_index_page_content_from_db() {
+        IndexContentReader reader = mock(IndexContentReader.class);
+        IndexPageGenerator generator = new IndexPageGenerator(
+            "/tmp/genidxpage",
+            reader
+        );
+
+        generator.readIndexContent();
+
+        verify(reader).readAllIndexContent();
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostRecorderTest.java
@@ -5,13 +5,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.dao.PostMapper;
 import org.gsh.genidxpage.entity.Post;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 class PostRecorderTest {
 
@@ -36,29 +33,5 @@ class PostRecorderTest {
         recorder.record("", 0L);
 
         verify(mapper).update(any(Post.class));
-    }
-
-    @DisplayName("기록된 모든 html을 읽어온다")
-    @Test
-    public void read_all_raw_html() {
-        PostMapper mapper = mock(PostMapper.class);
-        PostRecorder recorder = new PostRecorder(mapper);
-
-        List<Post> posts = List.of(
-            Post.createFrom("blogUrl1", 0L),
-            Post.createFrom("blogUrl2", 1L)
-        );
-        when(mapper.selectAll()).thenReturn(
-            posts
-        );
-
-        Assertions.assertThat(recorder.readAllRawHtml())
-            .isEqualTo(
-                posts.stream()
-                    .map(p -> p.getRawHtml())
-                    .toList()
-            );
-
-        verify(mapper).selectAll();
     }
 }


### PR DESCRIPTION
#### 기존 인덱스 파일을 사용할 때 다음과 같은 단점이 있었다:
- 폰트나 줄 간격 등이 정리되어 있지 않아 조잡해 보인다
- 모든 글 목록이 그룹화되지 않고 한 번에 나와 있어 원하는 글을 찾기 어렵다

#### 이러한 문제를 보완하기 위해 다음과 같은 변경을 적용했다:
- 인덱스 파일 스타일링
  - css 파일과 폰트 파일은 별도로 저장하지 않고, 배포 환경에 직접 포함시킨다

- 인덱스 파일에 연월 추가
  - 기존에는 post 테이블 정보만으로 인덱스 내용을 구성할 수 있어서
    PostRecorder에서 관련 책임을 맡고 있었다
  - 연월 정보가 추가되면서 post\_list\_page 테이블도 필요하게 되었고, 이 책임을
    PostRecorder에 계속 두기보다는 새로운 컴포넌트인 IndexContentReader를
    도입하기로 했다
  - IndexContentReader는 인덱스 생성과 관련된 데이터를 읽어오는 역할을 하기
     때문에, 인덱스 생성을 담당하는 IndexGenerator의 의존성으로 추가했다
  - 도입 이후 기존 ArchivePageService 쪽에 있던 관련 로직과 테스트는 제거했다
  - IndexContentReader가 반환하는 IndexContent는 식별자 없이 표현되는 값
    객체로, entity가 아닌 vo 패키지에 위치시켰다
  - IndexContent에 year와 month 필드를 따로 두는 대신 postListId 필드에 함께
    저장한다. 지금은 연월을 블로그 목록 구분 기준으로 사용하지만, 블로그마다 구분
    방식이 다를 수 있어 대비하려고 한다

#### 이외 변경 사항
- 변수명에 연속된 대문자 허용
  - loadedVOs처럼 대문자가 연속되는 변수명을 허용하도록 checkstyle 설정을
    수정했다
