### PR TITLE
pmd 설정한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ plugins {
 
 	id 'checkstyle'
     id 'org.ec4j.editorconfig' version '0.1.0'
+
+    id 'pmd'
 }
 
 group = 'org.gsh'
@@ -59,3 +61,8 @@ editorconfig {
 }
 
 check.dependsOn editorconfigCheck
+
+pmd {
+    toolVersion = "7.12.0"
+    ruleSetFiles = files("config/pmd/quickstart.xml")
+}

--- a/config/pmd/quickstart.xml
+++ b/config/pmd/quickstart.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="quickstart"
+  xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+  <description>Quickstart configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>
+
+  <!-- <rule ref="category/java/bestpractices.xml/AbstractClassWithoutAbstractMethod" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/AccessorClassGeneration" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/AccessorMethodGeneration" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/AvoidReassigningCatchVariables" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/AvoidReassigningLoopVariables" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters" /> -->
+  <rule ref="category/java/bestpractices.xml/AvoidMessageDigestField"/>
+  <rule ref="category/java/bestpractices.xml/AvoidStringBufferField"/>
+  <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
+  <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
+  <rule ref="category/java/bestpractices.xml/ConstantsInInterface"/>
+  <rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitch"/>
+  <rule ref="category/java/bestpractices.xml/DoubleBraceInitialization"/>
+  <!-- <rule ref="category/java/bestpractices.xml/ExhaustiveSwitchHasDefault"/> -->
+  <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
+  <!-- <rule ref="category/java/bestpractices.xml/ForLoopVariableCount" /> -->
+  <rule ref="category/java/bestpractices.xml/GuardLogStatement"/>
+  <!-- <rule ref="category/java/bestpractices.xml/ImplicitFunctionalInterface"/> -->
+  <!-- <rule ref="category/java/bestpractices.xml/JUnit4SuitesShouldUseSuiteAnnotation" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/JUnitUseExpected" /> -->
+  <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons" />
+  <rule ref="category/java/bestpractices.xml/LooseCoupling"/>
+  <!-- <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray" /> -->
+  <rule ref="category/java/bestpractices.xml/MissingOverride"/>
+  <rule ref="category/java/bestpractices.xml/NonExhaustiveSwitch"/>
+  <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
+  <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation"/>
+  <rule ref="category/java/bestpractices.xml/PreserveStackTrace"/>
+  <!-- <rule ref="category/java/bestpractices.xml/ReplaceEnumerationWithIterator" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList" /> -->
+  <rule ref="category/java/bestpractices.xml/SimplifiableTestAssertion"/>
+  <!-- <rule ref="category/java/bestpractices.xml/SystemPrintln" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnitTestAssertionsShouldIncludeMessage" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnitTestContainsTooManyAsserts" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnitTestShouldIncludeAssert" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnitTestShouldUseAfterAnnotation" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnitTestShouldUseBeforeAnnotation" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnitTestShouldUseTestAnnotation" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnnecessaryVarargsArrayCreation" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UnusedAssignment"/> -->
+  <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
+  <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
+  <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
+  <!-- <rule ref="category/java/bestpractices.xml/UseEnumCollections"/> -->
+  <rule ref="category/java/bestpractices.xml/UseStandardCharsets" />
+  <!-- <rule ref="category/java/bestpractices.xml/UseTryWithResources" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/UseVarargs" /> -->
+  <!-- <rule ref="category/java/bestpractices.xml/WhileLoopWithLiteralBoolean" /> -->
+
+
+  <!-- NAMING CONVENTIONS -->
+  <rule ref="category/java/codestyle.xml/ClassNamingConventions"/>
+  <!--<rule ref="category/java/codestyle.xml/FieldNamingConventions" />-->
+  <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
+  <rule ref="category/java/codestyle.xml/GenericsNaming"/>
+  <rule ref="category/java/codestyle.xml/LambdaCanBeMethodReference"/>
+  <!-- <rule ref="category/java/codestyle.xml/LinguisticNaming" /> -->
+  <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
+  <!-- <rule ref="category/java/codestyle.xml/LongVariable" /> -->
+  <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
+  <rule ref="category/java/codestyle.xml/PackageCase"/>
+  <!-- <rule ref="category/java/codestyle.xml/ShortClassName" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/ShortMethodName" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/ShortVariable" /> -->
+
+  <!-- <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/LocalInterfaceSessionNamingConvention" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/MDBAndSessionBeanNamingConvention" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/RemoteInterfaceNamingConvention" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/RemoteSessionInterfaceNamingConvention" /> -->
+
+  <!-- OTHER -->
+  <!-- <rule ref="category/java/codestyle.xml/AtLeastOneConstructor" /> -->
+  <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
+  <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
+  <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
+  <!-- <rule ref="category/java/codestyle.xml/AvoidUsingNativeCode"/>-->
+  <!-- <rule ref="category/java/codestyle.xml/BooleanGetMethodName" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/CallSuperInConstructor" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/ConfusingTernary" /> -->
+  <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
+  <!-- <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract" /> -->
+  <rule ref="category/java/codestyle.xml/ExtendsObject"/>
+  <!-- <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" /> -->
+  <rule ref="category/java/codestyle.xml/FinalParameterInAbstractMethod"/>
+  <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
+  <rule ref="category/java/codestyle.xml/IdenticalCatchBranches"/>
+  <!-- <rule ref="category/java/codestyle.xml/LocalVariableCouldBeFinal" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/MethodArgumentCouldBeFinal" /> -->
+  <rule ref="category/java/codestyle.xml/NoPackage"/>
+  <!-- <rule ref="category/java/codestyle.xml/UseExplicitTypes"/> -->
+  <!-- <rule ref="category/java/codestyle.xml/UseUnderscoresInNumericLiterals" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/OnlyOneReturn" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/PrematureDeclaration" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/TooManyStaticImports" /> -->
+  <rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement"/>
+  <!-- <rule ref="category/java/codestyle.xml/UnnecessaryBoxing" /> -->
+  <!-- <rule ref="category/java/codestyle.xml/UnnecessaryCast" /> -->
+  <rule ref="category/java/codestyle.xml/UnnecessaryConstructor"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
+  <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
+  <!-- <rule ref="category/java/codestyle.xml/UseDiamondOperator" /> -->
+  <rule ref="category/java/codestyle.xml/UselessParentheses"/>
+  <rule ref="category/java/codestyle.xml/UselessQualifiedThis"/>
+
+
+  <rule ref="category/java/design.xml/AbstractClassWithoutAnyMethod"/>
+  <!-- <rule ref="category/java/design.xml/AvoidCatchingGenericException" /> -->
+  <!-- <rule ref="category/java/design.xml/AvoidDeeplyNestedIfStmts" /> -->
+  <!-- <rule ref="category/java/design.xml/AvoidRethrowingException" /> -->
+  <!-- <rule ref="category/java/design.xml/AvoidThrowingNewInstanceOfSameException" /> -->
+  <!--<rule ref="category/java/design.xml/AvoidThrowingNullPointerException" />-->
+  <!-- <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" /> -->
+  <!-- <rule ref="category/java/design.xml/AvoidUncheckedExceptionsInSignatures" /> -->
+  <rule ref="category/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal"/>
+  <!-- <rule ref="category/java/design.xml/CognitiveComplexity" /> -->
+  <!-- <rule ref="category/java/design.xml/CollapsibleIfStatements"/>-->
+  <!-- <rule ref="category/java/design.xml/CouplingBetweenObjects" /> -->
+  <!-- <rule ref="category/java/design.xml/CyclomaticComplexity" /> -->
+  <!-- <rule ref="category/java/design.xml/DataClass" /> -->
+  <rule ref="category/java/design.xml/DoNotExtendJavaLangError" />
+  <!-- <rule ref="category/java/design.xml/ExceptionAsFlowControl" /> -->
+  <!-- <rule ref="category/java/design.xml/ExcessiveImports" /> -->
+  <!-- <rule ref="category/java/design.xml/ExcessiveParameterList" /> -->
+  <!-- <rule ref="category/java/design.xml/ExcessivePublicCount" /> -->
+  <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>
+  <!-- <rule ref="category/java/design.xml/GodClass" /> -->
+  <!-- <rule ref="category/java/design.xml/ImmutableField" /> -->
+  <!-- <rule ref="category/java/design.xml/InvalidJavaBean">-->
+  <!--     <properties>-->
+  <!--         <property name="packages" value="org.example.beans" />-->
+  <!--     </properties>-->
+  <!-- </rule>-->
+  <!-- <rule ref="category/java/design.xml/LawOfDemeter" /> -->
+  <rule ref="category/java/design.xml/LogicInversion"/>
+  <!-- <rule ref="category/java/design.xml/LoosePackageCoupling"> -->
+  <!--     <properties> -->
+  <!--         <property name="packages" value="org.sample,org.sample2" /> -->
+  <!--         <property name="classes" value="org.sample.SampleInterface,org.sample2.SampleInterface" /> -->
+  <!--     </properties> -->
+  <!-- </rule> -->
+  <!-- <rule ref="category/java/design.xml/MutableStaticState" /> -->
+  <!-- <rule ref="category/java/design.xml/NcssCount" /> -->
+  <!-- <rule ref="category/java/design.xml/NPathComplexity" /> -->
+  <!-- <rule ref="category/java/design.xml/SignatureDeclareThrowsException" /> -->
+  <rule ref="category/java/design.xml/SimplifiedTernary"/>
+  <!-- <rule ref="category/java/design.xml/SimplifyBooleanExpressions" /> -->
+  <rule ref="category/java/design.xml/SimplifyBooleanReturns"/>
+  <rule ref="category/java/design.xml/SimplifyConditional"/>
+  <rule ref="category/java/design.xml/SingularField"/>
+  <!-- <rule ref="category/java/design.xml/SwitchDensity" /> -->
+  <!-- <rule ref="category/java/design.xml/TooManyFields" /> -->
+  <!-- <rule ref="category/java/design.xml/TooManyMethods" /> -->
+  <rule ref="category/java/design.xml/UselessOverridingMethod"/>
+  <!-- <rule ref="category/java/design.xml/UseObjectForClearerAPI" /> -->
+  <rule ref="category/java/design.xml/UseUtilityClass"/>
+
+
+  <!-- <rule ref="category/java/documentation.xml/CommentContent" /> -->
+  <!-- <rule ref="category/java/documentation.xml/CommentRequired" /> -->
+  <!-- <rule ref="category/java/documentation.xml/CommentSize" /> -->
+  <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor"/>
+  <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
+
+
+
+  <rule ref="category/java/errorprone.xml/AssignmentInOperand">
+    <properties>
+      <property name="allowWhile" value="true"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/errorprone.xml/AssignmentToNonFinalStatic"/>
+  <rule ref="category/java/errorprone.xml/AvoidAccessibilityAlteration"/>
+  <!-- <rule ref="category/java/errorprone.xml/AvoidAssertAsIdentifier" /> -->
+  <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop"/>
+  <!-- <rule ref="category/java/errorprone.xml/AvoidCallingFinalize" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/AvoidCatchingNPE" /> -->
+  <rule ref="category/java/errorprone.xml/AvoidCatchingThrowable"/>
+  <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
+  <!-- <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/AvoidEnumAsIdentifier" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/AvoidFieldNameMatchingMethodName" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/AvoidFieldNameMatchingTypeName" /> -->
+  <rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause"/>
+  <!-- <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/AvoidLosingExceptionInformation" /> -->
+  <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators"/>
+  <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues"/>
+  <!-- <rule ref="category/java/errorprone.xml/BeanMembersShouldSerialize" /> -->
+  <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
+  <!-- <rule ref="category/java/errorprone.xml/CallSuperFirst" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/CallSuperLast" /> -->
+  <rule ref="category/java/errorprone.xml/CheckSkipResult"/>
+  <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray"/>
+  <rule ref="category/java/errorprone.xml/CloneMethodMustBePublic"/>
+  <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable"/>
+  <rule ref="category/java/errorprone.xml/CloneMethodReturnTypeMustMatchClassName"/>
+  <!-- <rule ref="category/java/errorprone.xml/CloneThrowsCloneNotSupportedException"/> deprecated since 6.35.0 -->
+  <rule ref="category/java/errorprone.xml/CloseResource"/>
+  <!-- <rule ref="category/java/errorprone.xml/ConfusingArgumentToVarargsMethod"/> -->
+  <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
+  <rule ref="category/java/errorprone.xml/ComparisonWithNaN"/>
+  <!-- <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/DataflowAnomalyAnalysis" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/DetachedTestCase" /> -->
+  <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>
+  <!-- <rule ref="category/java/errorprone.xml/DoNotCallSystemExit" /> -->
+  <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable"/>
+  <!-- <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally" /> -->
+  <!--<rule ref="category/java/errorprone.xml/DontImportSun" />-->
+  <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
+  <rule ref="category/java/errorprone.xml/EqualsNull"/>
+  <!-- <rule ref="category/java/errorprone.xml/FinalizeDoesNotCallSuperFinalize" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/FinalizeOnlyCallsSuperFinalize" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/FinalizeOverloaded" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected" /> -->
+  <rule ref="category/java/errorprone.xml/IdempotentOperations"/>
+  <rule ref="category/java/errorprone.xml/ImplicitSwitchFallThrough"/>
+  <rule ref="category/java/errorprone.xml/InstantiationToGetClass"/>
+  <!-- <rule ref="category/java/errorprone.xml/InvalidLogMessageFormat" /> -->
+  <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
+  <!-- <rule ref="category/java/errorprone.xml/JUnitSpelling" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/JUnitStaticSuite" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/LoggerIsNotStaticFinal" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass" /> -->
+  <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
+  <!-- <rule ref="category/java/errorprone.xml/MissingSerialVersionUID" /> -->
+  <rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass"/>
+  <!-- <rule ref="category/java/errorprone.xml/MoreThanOneLogger" /> -->
+  <rule ref="category/java/errorprone.xml/NonCaseLabelInSwitch"/>
+  <rule ref="category/java/errorprone.xml/NonStaticInitializer"/>
+  <!-- <rule ref="category/java/errorprone.xml/NullAssignment" /> -->
+  <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>
+  <rule ref="category/java/errorprone.xml/ProperCloneImplementation"/>
+  <rule ref="category/java/errorprone.xml/ProperLogger"/>
+  <rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull"/>
+  <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock"/>
+  <!-- <rule ref="category/java/errorprone.xml/SimpleDateFormatNeedsLocale" /> -->
+  <rule ref="category/java/errorprone.xml/SingleMethodSingleton"/>
+  <rule ref="category/java/errorprone.xml/SingletonClassReturningNewInstance"/>
+  <!-- <rule ref="category/java/errorprone.xml/StaticEJBFieldShouldBeFinal" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/StringBufferInstantiationWithChar" /> -->
+  <rule ref="category/java/errorprone.xml/SuspiciousEqualsMethodName"/>
+  <rule ref="category/java/errorprone.xml/SuspiciousHashcodeMethodName"/>
+  <rule ref="category/java/errorprone.xml/SuspiciousOctalEscape"/>
+  <!-- <rule ref="category/java/errorprone.xml/TestClassWithoutTestCases" /> -->
+  <rule ref="category/java/errorprone.xml/UnconditionalIfStatement"/>
+  <!-- <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion" /> -->
+  <!-- <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange" /> -->
+  <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary"/>
+  <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals"/>
+  <!-- <rule ref="category/java/errorprone.xml/UseCorrectExceptionLogging" /> -->
+  <rule ref="category/java/errorprone.xml/UseEqualsToCompareStrings"/>
+  <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
+  <rule ref="category/java/errorprone.xml/UseLocaleWithCaseConversions"/>
+  <!-- <rule ref="category/java/errorprone.xml/UseProperClassLoader" /> -->
+
+  <!-- Empty rules -->
+  <rule ref="category/java/codestyle.xml/EmptyControlStatement"/>
+  <rule ref="category/java/codestyle.xml/UnnecessarySemicolon"/>
+  <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
+  <rule ref="category/java/errorprone.xml/EmptyFinalizer"/>
+
+
+  <!-- <rule ref="category/java/multithreading.xml/AvoidSynchronizedAtMethodLevel" /> -->
+  <!-- <rule ref="category/java/multithreading.xml/AvoidSynchronizedStatement" /> -->
+  <rule ref="category/java/multithreading.xml/AvoidThreadGroup"/>
+  <rule ref="category/java/multithreading.xml/AvoidUsingVolatile"/>
+  <!-- <rule ref="category/java/multithreading.xml/DoNotUseThreads" /> -->
+  <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
+  <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
+  <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton"/>
+  <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter"/>
+  <!-- <rule ref="category/java/multithreading.xml/UseConcurrentHashMap" /> -->
+  <rule ref="category/java/multithreading.xml/UseNotifyAllInsteadOfNotify"/>
+
+
+  <!-- <rule ref="category/java/performance.xml/AddEmptyString" /> -->
+  <!-- <rule ref="category/java/performance.xml/AppendCharacterWithChar" /> -->
+  <!-- <rule ref="category/java/performance.xml/AvoidArrayLoops" /> -->
+  <!-- <rule ref="category/java/performance.xml/AvoidCalendarDateCreation" /> -->
+  <!-- <rule ref="category/java/performance.xml/AvoidFileStream" /> -->
+  <!-- <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops" /> -->
+  <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
+  <!-- <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse" /> -->
+  <!-- <rule ref="category/java/performance.xml/ConsecutiveLiteralAppends" /> -->
+  <!-- <rule ref="category/java/performance.xml/InefficientEmptyStringCheck" /> -->
+  <!-- <rule ref="category/java/performance.xml/InefficientStringBuffering" /> -->
+  <!-- <rule ref="category/java/performance.xml/InsufficientStringBufferDeclaration" /> -->
+  <rule ref="category/java/performance.xml/OptimizableToArrayCall"/>
+  <!--<rule ref="category/java/performance.xml/RedundantFieldInitializer"/>-->
+  <!-- <rule ref="category/java/performance.xml/StringInstantiation" /> -->
+  <!-- <rule ref="category/java/performance.xml/StringToString" /> -->
+  <!-- <rule ref="category/java/performance.xml/TooFewBranchesForSwitch"/> -->
+  <!-- <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector" /> -->
+  <!-- <rule ref="category/java/performance.xml/UseArraysAsList" /> -->
+  <!-- <rule ref="category/java/performance.xml/UseIndexOfChar" /> -->
+  <!-- <rule ref="category/java/performance.xml/UseIOStreamsWithApacheCommonsFileItem" /> -->
+  <!-- <rule ref="category/java/performance.xml/UselessStringValueOf" /> -->
+  <!-- <rule ref="category/java/performance.xml/UseStringBufferForStringAppends" /> -->
+  <!-- <rule ref="category/java/performance.xml/UseStringBufferLength" /> -->
+
+
+  <!-- <rule ref="category/java/security.xml/HardCodedCryptoKey" /> -->
+  <!-- <rule ref="category/java/security.xml/InsecureCryptoIv" /> -->
+</ruleset>

--- a/config/pmd/quickstart.xml
+++ b/config/pmd/quickstart.xml
@@ -70,7 +70,11 @@
   <!-- <rule ref="category/java/codestyle.xml/LinguisticNaming" /> -->
   <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
   <!-- <rule ref="category/java/codestyle.xml/LongVariable" /> -->
-  <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
+  <rule ref="category/java/codestyle.xml/MethodNamingConventions">
+    <properties>
+      <property name="junit5TestPattern" value="[a-z][a-zA-Z0-9_]*"/>
+    </properties>
+  </rule>
   <rule ref="category/java/codestyle.xml/PackageCase"/>
   <!-- <rule ref="category/java/codestyle.xml/ShortClassName" /> -->
   <!-- <rule ref="category/java/codestyle.xml/ShortMethodName" /> -->

--- a/config/pmd/quickstart.xml
+++ b/config/pmd/quickstart.xml
@@ -23,7 +23,7 @@
   <!-- <rule ref="category/java/bestpractices.xml/ExhaustiveSwitchHasDefault"/> -->
   <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
   <!-- <rule ref="category/java/bestpractices.xml/ForLoopVariableCount" /> -->
-  <rule ref="category/java/bestpractices.xml/GuardLogStatement"/>
+<!--  <rule ref="category/java/bestpractices.xml/GuardLogStatement"/>-->
   <!-- <rule ref="category/java/bestpractices.xml/ImplicitFunctionalInterface"/> -->
   <!-- <rule ref="category/java/bestpractices.xml/JUnit4SuitesShouldUseSuiteAnnotation" /> -->
   <!-- <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" /> -->
@@ -51,7 +51,7 @@
   <!-- <rule ref="category/java/bestpractices.xml/UnusedAssignment"/> -->
   <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
-  <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
+<!--  <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>-->
   <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
   <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
   <!-- <rule ref="category/java/bestpractices.xml/UseEnumCollections"/> -->
@@ -170,14 +170,14 @@
   <!-- <rule ref="category/java/design.xml/TooManyMethods" /> -->
   <rule ref="category/java/design.xml/UselessOverridingMethod"/>
   <!-- <rule ref="category/java/design.xml/UseObjectForClearerAPI" /> -->
-  <rule ref="category/java/design.xml/UseUtilityClass"/>
+<!--  <rule ref="category/java/design.xml/UseUtilityClass"/>-->
 
 
   <!-- <rule ref="category/java/documentation.xml/CommentContent" /> -->
   <!-- <rule ref="category/java/documentation.xml/CommentRequired" /> -->
   <!-- <rule ref="category/java/documentation.xml/CommentSize" /> -->
-  <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor"/>
-  <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
+<!--  <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor"/>-->
+<!--  <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>-->
 
 
 

--- a/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
@@ -37,9 +37,8 @@ public class BulkRequestSender {
             throw new FailToReadRequestInputFileException(e, ErrorCode.SERVER_FAULT, "fail to read request input file");
         }
 
-        List<String> yearMonths = Arrays.stream(fileContent.strip().split("\n"))
+        return Arrays.stream(fileContent.strip().split("\n"))
             .collect(ArrayList::new, List::add, List::addAll);
-        return yearMonths;
     }
 
     public void sendAll(List<String> yearMonths, ArchivePageService sender) {

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -29,6 +29,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
     }
 
     @Transactional
+    @Override
     public String findBlogPageLink(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = this.findArchivedPageInfo(dto);
         if (archivedPageInfo.isEmpty()) {
@@ -72,8 +73,6 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         WebPageParser webPageParser = new WebPageParser();
         List<PostLinkInfo> postLinks = webPageParser.findPostLinks(blogPost);
 
-        String pageLinksConcat = webPageParser.buildPageLinks(postLinks);
-
-        return pageLinksConcat;
+        return webPageParser.buildPageLinks(postLinks);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ArchivePageService {
 
-    String findBlogPageLink(final CheckPostArchivedDto dto);
+    String findBlogPageLink(CheckPostArchivedDto dto);
 
     List<String> findFailedRequests();
 }

--- a/src/main/java/org/gsh/genidxpage/service/IndexContentReader.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexContentReader.java
@@ -1,6 +1,7 @@
 package org.gsh.genidxpage.service;
 
 import org.gsh.genidxpage.dao.IndexContentMapper;
+import org.gsh.genidxpage.vo.IndexContent;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,9 +18,7 @@ public class IndexContentReader {
     public List<String> readAllIndexContent() {
         return mapper.selectAll()
             .stream()
-            .map(indexContent -> {
-                return indexContent.toString();
-            })
+            .map(IndexContent::toString)
             .toList();
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
+++ b/src/main/java/org/gsh/genidxpage/service/WebPageParser.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+// LooseCoupling 룰을 맞추려고 Elements 대신 List<Element>를 쓰면
+// Elements에서 구현한 메서드를 쓸 수 없다
+@SuppressWarnings("PMD.LooseCoupling")
 class WebPageParser {
 
     List<PostLinkInfo> findPostLinks(String stringDoc) {

--- a/src/main/java/org/gsh/genidxpage/service/dto/EmptyArchivedPageInfo.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/EmptyArchivedPageInfo.java
@@ -2,6 +2,7 @@ package org.gsh.genidxpage.service.dto;
 
 public class EmptyArchivedPageInfo extends ArchivedPageInfo {
 
+    @Override
     public boolean isEmpty() {
         return true;
     }

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -21,8 +21,8 @@ public class ArchivePageController {
 
     @GetMapping("/post-links/{year}/{month}")
     public ResponseEntity<String> getBlogPostLinks(
-        @PathVariable(value = "year") String year,
-        @PathVariable(value = "month") String month
+        @PathVariable("year") String year,
+        @PathVariable("month") String month
     ) {
         CheckPostArchivedDto dto = new CheckPostArchivedDto(year, month);
         String pageLinks = service.findBlogPageLink(dto);

--- a/src/main/java/org/gsh/genidxpage/web/response/PostLinkInfo.java
+++ b/src/main/java/org/gsh/genidxpage/web/response/PostLinkInfo.java
@@ -2,7 +2,8 @@ package org.gsh.genidxpage.web.response;
 
 public class PostLinkInfo {
 
-    private final String baseUrl = "https://web.archive.org";
+    private static final String BASE_URL = "https://web.archive.org";
+
     private String pageUrl;
     private String pageTitle;
 
@@ -20,6 +21,6 @@ public class PostLinkInfo {
     }
 
     public String buildPageLink() {
-        return String.format("<a href=\"%s%s\">%s</a>", baseUrl, pageUrl, pageTitle);
+        return String.format("<a href=\"%s%s\">%s</a>", BASE_URL, pageUrl, pageTitle);
     }
 }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -250,7 +250,7 @@ public class AcceptanceTest {
 
             // 정상 응답할 입력을 설정한다
             List<String> passRequests = requestInput.stream()
-                .filter(ym -> ym.split("/")[0].equals("2021"))
+                .filter(ym -> "2021".equals(ym.split("/")[0]))
                 .toList();
             passRequests.forEach(yearMonth -> {
                 String[] pair = yearMonth.split("/");
@@ -262,7 +262,7 @@ public class AcceptanceTest {
             });
             // 비정상 응답할 입력을 설정한다
             List<String> failRequests = requestInput.stream()
-                .filter(ym -> !ym.split("/")[0].equals("2021"))
+                .filter(ym -> !"2021".equals(ym.split("/")[0]))
                 .toList();
             failRequests.forEach(yearMonth -> {
                 String[] pair = yearMonth.split("/");

--- a/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
@@ -38,7 +38,7 @@ class BulkRequestSenderTest {
 
         assertThrows(
             FailToReadRequestInputFileException.class,
-            () -> bulkRequestSender.prepareInput()
+            bulkRequestSender::prepareInput
         );
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/WebArchiveApiCallerTest.java
@@ -2,7 +2,6 @@ package org.gsh.genidxpage.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.FakeWebArchiveServer;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
@@ -72,7 +71,7 @@ class WebArchiveApiCallerTest {
         fakeWebArchiveServer.start();
 
         CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
-        Assertions.assertThat(caller.findArchivedPageInfo(dto))
+        assertThat(caller.findArchivedPageInfo(dto))
             .isInstanceOf(ArchivedPageInfo.class);
 
         fakeWebArchiveServer.stop();
@@ -86,7 +85,7 @@ class WebArchiveApiCallerTest {
             CustomRestTemplateBuilder.get());
 
         CheckPostArchivedDto dto = new CheckPostArchivedDto("2023", "1");
-        Assertions.assertThat(caller.buildUri(dto)).matches(
+        assertThat(caller.buildUri(dto)).matches(
             "http://localhost:8080/wayback/available\\?url=https://agile.egloos.com/archives/2023/01&timestamp=\\d{8}"
         );
     }
@@ -99,14 +98,14 @@ class WebArchiveApiCallerTest {
             CustomRestTemplateBuilder.get());
         CheckPostArchivedDto dto = new CheckPostArchivedDto("2021", "3");
 
-        Assertions.assertThat(callerWithTimestamp.buildUri(dto)).matches(
+        assertThat(callerWithTimestamp.buildUri(dto)).matches(
             "http://localhost:8080/wayback/available\\?url=[^&]*&timestamp=\\d{8}"
         );
 
         WebArchiveApiCaller callerWithoutTimestamp = new WebArchiveApiCaller("http://localhost:8080",
             "/wayback/available?url={url}",
             CustomRestTemplateBuilder.get());
-        Assertions.assertThat(callerWithoutTimestamp.buildUri(dto)).matches(
+        assertThat(callerWithoutTimestamp.buildUri(dto)).matches(
             "http://localhost:8080/wayback/available\\?url=[^&]*"
         );
     }


### PR DESCRIPTION
#### 작업 내용
- pmd 프로젝트에서 제공하는 quickstart.xml 설정을 기반으로 하되, 현재 프로젝트 상황에 맞게 조정한다
- pmd로 설정한 ruleset을 만족하도록 소스 코드를 수정한다

#### 이외
- pmd로 해결하고자 했던 아래 두 설정은 pmd로는 구현하기 어렵다고 판단했다
- 'final 키워드를 추가할 수 있는 곳인데 쓰지 않은 경우를 체크한다'의 경우,
  - final 키워드와 관련된 pmd 룰인 MethodArgumentCouldBeFinal과 LocalVariableCouldBeFinal을 적용해본 결과,
  모든 위치에 final 키워드를 붙여야 했고 오히려 가독성이 떨어졌다
  - 대신 final 키워드가 사용될 수 있는 위치와 그 효과를 기준으로 정책을 정하고, pmd 외에 그 정책을 지원할 수 있는 방안을
  찾는 편이 낫다고 판단했다
  - pmd를 쓴다면 @SuppressWarnings나 디렉토리 단위 제외 같은 방식으로 pmd 룰 적용 범위를 제한할 수 있겠지만,
  원하는 만큼 구현하기는 어려워 보이기 때문이다
- '클래스와 멤버의 접근 권한을 최소화한다'의 경우,
  - 관련된 pmd 룰로는 UseUtilityClass, MethodCanBeStatic, UnnecessaryModifier가 있었지만 접근 권한 자체를
  더 줄일 수 있는지를 파악하는 룰은 없는 것 같다
  - 따라서 이 항목 역시 pmd로 해결하기는 어렵다고 판단했다
