### PR TITLE
재시도 기준을 개선한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/dao/ArchiveStatusMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/ArchiveStatusMapper.java
@@ -16,4 +16,6 @@ public interface ArchiveStatusMapper {
     void update(ArchiveStatus report);
 
     List<ArchiveStatus> selectByPageExists(Boolean pageExists);
+
+    List<ArchiveStatus> selectAllFailed();
 }

--- a/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchiveStatusReporter.java
@@ -39,7 +39,7 @@ public class ArchiveStatusReporter {
     }
 
     List<String> readAllFailedRequestInput() {
-        return reportMapper.selectByPageExists(Boolean.FALSE)
+        return reportMapper.selectAllFailed()
             .stream()
             .map(report -> report.getYear() + "/" + report.getMonth())
             .toList();

--- a/src/main/resources/mapper/ArchiveStatusMapper.xml
+++ b/src/main/resources/mapper/ArchiveStatusMapper.xml
@@ -47,11 +47,9 @@
   <select id="selectAllFailed" resultType="org.gsh.genidxpage.entity.ArchiveStatus">
     select plps.year, plps.month, plps.page_exists
     from post_list_page_status plps
-           join post_list_page plp
+           left join post_list_page plp
                 on concat(plps.year, '/', plps.month) = concat(plp.year, '/', plp.month)
-           left join post p
-                     on p.parent_page_id = plp.id
     where plps.page_exists = false
-      and p.id is null;
+      and plp.id is null;
   </select>
 </mapper>

--- a/src/main/resources/mapper/ArchiveStatusMapper.xml
+++ b/src/main/resources/mapper/ArchiveStatusMapper.xml
@@ -43,4 +43,15 @@
     WHERE page_exists = #{pageExists}
       AND deleted_at IS NULL
   </select>
+
+  <select id="selectAllFailed" resultType="org.gsh.genidxpage.entity.ArchiveStatus">
+    select plps.year, plps.month, plps.page_exists
+    from post_list_page_status plps
+           join post_list_page plp
+                on concat(plps.year, '/', plps.month) = concat(plp.year, '/', plp.month)
+           left join post p
+                     on p.parent_page_id = plp.id
+    where plps.page_exists = false
+      and p.id is null;
+  </select>
 </mapper>

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -16,6 +16,7 @@ import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.ArchivePageController;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -239,6 +240,7 @@ public class AcceptanceTest {
             fakeWebArchiveServer.stop();
         }
 
+        @Disabled("재시도 조건 변경을 추후 반영해야 한다")
         @DisplayName("실패한 요청을 모아서 재시도한다")
         @Test
         public void retry_failed_requests() {

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -16,7 +16,6 @@ import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
 import org.gsh.genidxpage.web.ArchivePageController;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -240,7 +239,6 @@ public class AcceptanceTest {
             fakeWebArchiveServer.stop();
         }
 
-        @Disabled("재시도 조건 변경을 추후 반영해야 한다")
         @DisplayName("실패한 요청을 모아서 재시도한다")
         @Test
         public void retry_failed_requests() {

--- a/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchiveStatusReporterTest.java
@@ -73,11 +73,11 @@ class ArchiveStatusReporterTest {
                 .buildAsNew()
         );
 
-        when(mapper.selectByPageExists(any())).thenReturn(failRequestReports);
+        when(mapper.selectAllFailed()).thenReturn(failRequestReports);
 
         Assertions.assertThat(reporter.readAllFailedRequestInput())
             .isEqualTo(List.of("2020/05", "2021/03"));
 
-        verify(mapper).selectByPageExists(any());
+        verify(mapper).selectAllFailed();
     }
 }


### PR DESCRIPTION
#### 재시도 기준을 개선한다
- 기존 재시도 기준은 post_list_page_status.page_exists = false인 경우지만, 이전 시도 중에 한번이라도 성공했다면 (다시 성공하지 않는 이상) 해당 연월의 글 목록 페이지 url과 각 블로그 글들에 접근할 수 있는 링크가 html 형식으로 저장된다.
- 현재 구현에선 이전에 한 번이라도 (위에서 이야기한) url과 html을 db에 저장했다면, 마지막 시도에서 실패했더라도 db에는 성공한 데이터가 저장되어 있기 때문에 post_list_page_status.page_exists = false 인 요청이 재시도할 요청이라고 확언하기는 어렵다.
- 따라서 재시도 시도가 필요한 요청인지 판단하는 기준을 개선한다. post_list_page_status.page_exists = false인 조건에 더해, 해당 연월에 대한 access_url이 post_list_page 테이블에 등록되지 않은 경우만 재시도하도록 바꾼다.
