### PR TITLE
진행 상황 확인하기 용이하게 로그를 개선한다

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -238,7 +238,7 @@
                      value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="LocalVariableName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>

--- a/src/main/java/org/gsh/genidxpage/repository/PostListPageRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/repository/PostListPageRecorder.java
@@ -24,14 +24,14 @@ public class PostListPageRecorder {
         );
 
         if (hasPostListPage != null) {
-            log.info(
+            log.debug(
                 "updating access url with id of " + hasPostListPage.getId() + " with content of "
                     + archivedPageInfo.accessibleUrl());
             mapper.update(PostListPage.updateFrom(hasPostListPage, archivedPageInfo));
             return hasPostListPage.getId();
         }
 
-        log.info("inserting access url of " + archivedPageInfo.accessibleUrl());
+        log.debug("inserting access url of " + archivedPageInfo.accessibleUrl());
         PostListPage postListPage = PostListPage.createFrom(dto, archivedPageInfo);
         mapper.insert(postListPage);
         return postListPage.getId();

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -38,7 +38,7 @@ public class AgileStoryArchivePageService implements ArchivePageService {
     public String findBlogPageLink(final CheckPostArchivedDto dto) {
         ArchivedPageInfo archivedPageInfo = this.findArchivedPageInfo(dto);
         if (archivedPageInfo.isUnreachable()) {
-            log.info(
+            log.debug(
                 String.format("fail to read blog page link for %s/%s due to timeout",
                     dto.getYear(), dto.getMonth())
             );
@@ -46,12 +46,12 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         }
 
         if (archivedPageInfo.isEmpty()) {
-            log.info(
+            log.debug(
                 String.format("empty blog page link for %s/%s", dto.getYear(), dto.getMonth()));
             return "";
         }
         Long listPageId = listPageRecorder.record(dto, archivedPageInfo);
-        log.info("id of post list page inserted/updated now is {" + listPageId + "}");
+        log.debug("id of post list page inserted/updated now is {" + listPageId + "}");
 
         String blogPost = this.findBlogPostPage(archivedPageInfo);
         postRecorder.record(this.buildPageLinks(blogPost), listPageId);

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.junit.jupiter.api.DisplayName;
@@ -81,5 +82,17 @@ class WebArchiveSchedulerTest {
 
         verify(service).findFailedRequests();
         verify(sender).sendAll(any(), any(ArchivePageService.class));
+    }
+
+    @DisplayName("재시도 이후 실패/성공한 요청 정보를 알아낼 수 있다")
+    @Test
+    public void get_success_fail_info_after_retry() {
+        List<String> sendInfo = List.of("2020/01", "2020/02", "2020/03", "2020/04");
+        List<String> failedAfterRetry = List.of("2020/01", "2020/02");
+        WebArchiveScheduler scheduler = new WebArchiveScheduler(
+            null, null, null
+        );
+        Assertions.assertThat(scheduler.successAfterRetry(sendInfo, failedAfterRetry))
+            .isEqualTo(List.of("2020/03", "2020/04"));
     }
 }

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveSchedulerTest.java
@@ -1,6 +1,7 @@
 package org.gsh.genidxpage.scheduler;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -80,7 +81,7 @@ class WebArchiveSchedulerTest {
 
         scheduler.doRetry();
 
-        verify(service).findFailedRequests();
+        verify(service, atLeast(1)).findFailedRequests();
         verify(sender).sendAll(any(), any(ArchivePageService.class));
     }
 


### PR DESCRIPTION
- 기존 로그 설정에서 진행상황을 확인하는 게 번거로워서, 확인하기 용이하게 로그를 바꾼다
- 각 요청마다 로그를 출력하는 기존 로그는 필요할 때만 출력할 수 있게 로그 레벨을 debug로 바꾼다
- 다음 로그를 추가한다:
  - 처음 시도한 요청은 갯수만 표시
  - 실패한 요청 갯수와 입력값 요약
  - 재시도 후 성공/실패한 요청 각각의 갯수와 입력값 요약

- 깨지는 테스트 고친다
  - findFailedRequests()를 로깅 시 호출해서 호출 횟수가 2회로 늘어나고,
   verify() 문에서 기대하는 호출 횟수와 달라서 테스트가 실패한다
  - atLeast로 findFailedRequests()가 적어도 1회 호출되는지만 단정한다.
   로깅 쪽 호출은 이 테스트에서 확인하려는 것과 연관이 적기 때문이다

- checkstyle 설정 고친다
  - WebArchiveScheduler의 aSendInfo 변수명을 쓸 수 있도록 설정을 바꾼다