### PR TITLE
그룹핑 기준이 다른 블로그도 저장할 수 있도록 db 스키마를 일반화한다

### DIFF
--- a/src/main/resources/db/migration/V2_0__add_post_group_type.sql
+++ b/src/main/resources/db/migration/V2_0__add_post_group_type.sql
@@ -1,0 +1,13 @@
+# 연월 이외 다른 기준으로 블로그 글을 그룹핑하는 블로그도 처리할 수 있도록 블로그 글 그룹핑 기준 테이블을 추가한다
+CREATE TABLE post_group_type
+(
+    id         BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    value      VARCHAR(255)       NOT NULL,
+    created_at DATETIME,
+    updated_at DATETIME,
+    deleted_at DATETIME
+);
+
+INSERT INTO post_group_type (value, created_at)
+VALUES ('year_month', CURRENT_DATE()),
+       ('category', CURRENT_DATE());

--- a/src/main/resources/db/migration/V2_0__add_post_group_type.sql
+++ b/src/main/resources/db/migration/V2_0__add_post_group_type.sql
@@ -1,13 +1,13 @@
-# 연월 이외 다른 기준으로 블로그 글을 그룹핑하는 블로그도 처리할 수 있도록 블로그 글 그룹핑 기준 테이블을 추가한다
+-- 연월 이외 다른 기준으로 블로그 글을 그룹핑하는 블로그도 처리할 수 있도록 블로그 글 그룹핑 기준 테이블을 추가한다
 CREATE TABLE post_group_type
 (
     id         BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-    value      VARCHAR(255)       NOT NULL,
+    group_type VARCHAR(255)       NOT NULL,
     created_at DATETIME,
     updated_at DATETIME,
     deleted_at DATETIME
 );
 
-INSERT INTO post_group_type (value, created_at)
+INSERT INTO post_group_type (group_type, created_at)
 VALUES ('year_month', CURRENT_DATE()),
        ('category', CURRENT_DATE());

--- a/src/main/resources/db/migration/V2_1__apply_group_type_to_post_list_page_status.sql
+++ b/src/main/resources/db/migration/V2_1__apply_group_type_to_post_list_page_status.sql
@@ -1,16 +1,18 @@
-# 기존 post_list_page_status 테이블의 데이터가 새로 추가한 post_group_type에 연결되도록 업데이트한다
+-- 기존 post_list_page_status 테이블의 데이터가 새로 추가한 post_group_type에 연결되도록 업데이트한다
 ALTER TABLE post_list_page_status
-    ADD COLUMN post_group_type_id BIGINT,
+    ADD COLUMN post_group_type_id BIGINT;
+ALTER TABLE post_list_page_status
     ADD COLUMN group_key VARCHAR(255);
 
 UPDATE post_list_page_status
 SET post_group_type_id = (SELECT id
                           FROM post_group_type pgt
-                          WHERE pgt.value = 'year_month'),
+                          WHERE pgt.group_type = 'year_month'),
     group_key    = CONCAT(year, '/', month);
 
 ALTER TABLE post_list_page_status
-    MODIFY post_group_type_id BIGINT NOT NULL,
+    MODIFY post_group_type_id BIGINT NOT NULL;
+ALTER TABLE post_list_page_status
     MODIFY group_key VARCHAR (255) NOT NULL;
 
 ALTER TABLE post_list_page_status

--- a/src/main/resources/db/migration/V2_1__apply_group_type_to_post_list_page_status.sql
+++ b/src/main/resources/db/migration/V2_1__apply_group_type_to_post_list_page_status.sql
@@ -1,0 +1,17 @@
+# 기존 post_list_page_status 테이블의 데이터가 새로 추가한 post_group_type에 연결되도록 업데이트한다
+ALTER TABLE post_list_page_status
+    ADD COLUMN post_group_type_id BIGINT,
+    ADD COLUMN group_key VARCHAR(255);
+
+UPDATE post_list_page_status
+SET post_group_type_id = (SELECT id
+                          FROM post_group_type pgt
+                          WHERE pgt.value = 'year_month'),
+    group_key    = CONCAT(year, '/', month);
+
+ALTER TABLE post_list_page_status
+    MODIFY post_group_type_id BIGINT NOT NULL,
+    MODIFY group_key VARCHAR (255) NOT NULL;
+
+ALTER TABLE post_list_page_status
+    ADD FOREIGN KEY (post_group_type_id) REFERENCES post_group_type (id);

--- a/src/main/resources/db/migration/V2_1__apply_group_type_to_post_list_page_status.sql
+++ b/src/main/resources/db/migration/V2_1__apply_group_type_to_post_list_page_status.sql
@@ -11,9 +11,4 @@ SET post_group_type_id = (SELECT id
     group_key    = CONCAT(year, '/', month);
 
 ALTER TABLE post_list_page_status
-    MODIFY post_group_type_id BIGINT NOT NULL;
-ALTER TABLE post_list_page_status
-    MODIFY group_key VARCHAR (255) NOT NULL;
-
-ALTER TABLE post_list_page_status
     ADD FOREIGN KEY (post_group_type_id) REFERENCES post_group_type (id);

--- a/src/main/resources/db/migration/V2_2__apply_group_type_to_post_list_page.sql
+++ b/src/main/resources/db/migration/V2_2__apply_group_type_to_post_list_page.sql
@@ -1,16 +1,18 @@
-# 기존 post_list_page 테이블의 데이터가 새로 추가한 post_group_type에 연결되도록 업데이트한다
+-- 기존 post_list_page 테이블의 데이터가 새로 추가한 post_group_type에 연결되도록 업데이트한다
 ALTER TABLE post_list_page
-    ADD COLUMN post_group_type_id BIGINT,
+    ADD COLUMN post_group_type_id BIGINT;
+ALTER TABLE post_list_page
     ADD COLUMN group_key VARCHAR(255);
 
 UPDATE post_list_page
 SET post_group_type_id = (SELECT id
                           FROM post_group_type pgt
-                          WHERE pgt.value = 'year_month'),
+                          WHERE pgt.group_type = 'year_month'),
     group_key    = CONCAT(year, '/', month);
 
 ALTER TABLE post_list_page
-    MODIFY post_group_type_id BIGINT NOT NULL,
+    MODIFY post_group_type_id BIGINT NOT NULL;
+ALTER TABLE post_list_page
     MODIFY group_key VARCHAR(255) NOT NULL;
 
 ALTER TABLE post_list_page

--- a/src/main/resources/db/migration/V2_2__apply_group_type_to_post_list_page.sql
+++ b/src/main/resources/db/migration/V2_2__apply_group_type_to_post_list_page.sql
@@ -1,0 +1,17 @@
+# 기존 post_list_page 테이블의 데이터가 새로 추가한 post_group_type에 연결되도록 업데이트한다
+ALTER TABLE post_list_page
+    ADD COLUMN post_group_type_id BIGINT,
+    ADD COLUMN group_key VARCHAR(255);
+
+UPDATE post_list_page
+SET post_group_type_id = (SELECT id
+                          FROM post_group_type pgt
+                          WHERE pgt.value = 'year_month'),
+    group_key    = CONCAT(year, '/', month);
+
+ALTER TABLE post_list_page
+    MODIFY post_group_type_id BIGINT NOT NULL,
+    MODIFY group_key VARCHAR(255) NOT NULL;
+
+ALTER TABLE post_list_page
+    ADD FOREIGN KEY (post_group_type_id) REFERENCES post_group_type (id);

--- a/src/main/resources/db/migration/V2_2__apply_group_type_to_post_list_page.sql
+++ b/src/main/resources/db/migration/V2_2__apply_group_type_to_post_list_page.sql
@@ -11,9 +11,4 @@ SET post_group_type_id = (SELECT id
     group_key    = CONCAT(year, '/', month);
 
 ALTER TABLE post_list_page
-    MODIFY post_group_type_id BIGINT NOT NULL;
-ALTER TABLE post_list_page
-    MODIFY group_key VARCHAR(255) NOT NULL;
-
-ALTER TABLE post_list_page
     ADD FOREIGN KEY (post_group_type_id) REFERENCES post_group_type (id);


### PR DESCRIPTION
- 블로그 그룹핑 기준을 일반화하기 위해 DB 스키마 수정한다
  - 기존 연월 기반에서 블로그 인덱스를 구분하던 방식에서 확장 가능하도록
    구조를 변경한다
  - post_group_type 테이블에서 블로그 인덱스 구분 기준을 확인할 수 있다
  - post_list_page_status, post_list_page 테이블에 post_group_type_id,
    group_key 컬럼을 추가해서 post_group_type 정보를 알 수 있게 한다
  - 기존에 year, month 컬럼에 저장된 값을 post_group_type을 이용한
    로직에서 쓸 수 있도록 group_key에 복사한다. year, month에 있는 값은
    추후 점진적으로 바꿀 예정이다

- H2와 mysql 둘 다에서 정상 작동하도록 sql 구문을 고친다
  - 주석에 # 대신 --
  - 예약어인 value 대신 group_type
  - ALTER TABLE문 하나에 여러 연산 동시에 하지 않도록

- 추가한 컬럼은 NULL을 허용한다
  - NOT NULL 제약을 설정할 경우, 기존 코드 모두에 새로 추가된 컬럼이
    기본값으로 들어가도록 반영해야 한다
  - 먼저 제약 없이 추가한 뒤에 점진적으로 반영 후 다시 제약을 설정하려고
    한다