### PR TITLE
새로운 블로그 인덱스 페이지 생성 로직 추가할 수 있도록 인터페이스를 도입한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/BulkRequestSender.java
@@ -1,55 +1,12 @@
 package org.gsh.genidxpage.scheduler;
 
-import org.gsh.genidxpage.common.exception.ErrorCode;
-import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
 import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-@Component
-public class BulkRequestSender {
+public interface BulkRequestSender {
 
-    private final String inputPath;
+    List<String> prepareInput();
 
-    public BulkRequestSender(@Value("${bulk-request.input-path}") final String inputPath) {
-        this.inputPath = inputPath;
-    }
-
-    public List<String> prepareInput() {
-        ClassPathResource classPathResource = new ClassPathResource(inputPath);
-        String fileContent = "";
-
-        try {
-            Path  path = Paths.get(classPathResource.getURI());
-            fileContent = Files.readString(path, StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new FailToReadRequestInputFileException(e, ErrorCode.SERVER_FAULT, "fail to read request input file");
-        }
-
-        return Arrays.stream(fileContent.strip().split("\n"))
-            .collect(ArrayList::new, List::add, List::addAll);
-    }
-
-    public void sendAll(List<String> yearMonths, ArchivePageService sender) {
-        yearMonths.forEach(yearMonth -> {
-            // 외부 서버에 요청할 입력 형식으로 파일 내용을 정제한다
-            String[] pair = yearMonth.split("/");
-            String year = pair[0];
-            String month = pair[1];
-            CheckPostArchivedDto dto = new CheckPostArchivedDto(year, month);
-
-            sender.findBlogPageLink(dto);
-        });
-    }
+    void sendAll(List<String> requestInputs, ArchivePageService sender);
 }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveJob.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveJob.java
@@ -1,0 +1,82 @@
+package org.gsh.genidxpage.scheduler;
+
+import org.gsh.genidxpage.service.ArchivePageService;
+import org.gsh.genidxpage.service.IndexPageGenerator;
+import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class WebArchiveJob {
+
+    private final BulkRequestSender bulkRequestSender;
+    private final ArchivePageService archivePageService;
+    private final IndexPageGenerator indexPageGenerator;
+
+    public WebArchiveJob(BulkRequestSender bulkRequestSender, ArchivePageService archivePageService,
+        IndexPageGenerator indexPageGenerator) {
+        this.bulkRequestSender = bulkRequestSender;
+        this.archivePageService = archivePageService;
+        this.indexPageGenerator = indexPageGenerator;
+    }
+
+    public void execute() {
+        doSend();
+        doRetry();
+        List<String> pageLinkList = readIndexContent();
+        doGenerate(pageLinkList);
+    }
+
+    public void doSend() {
+        List<String> yearMonths = bulkRequestSender.prepareInput();
+        reportSendInfo(yearMonths);
+        bulkRequestSender.sendAll(yearMonths, archivePageService);
+    }
+
+    public void doRetry() {
+        List<String> yearMonths = archivePageService.findFailedRequests();
+        reportRetryInfo(yearMonths);
+        bulkRequestSender.sendAll(yearMonths, archivePageService);
+        reportRetryResult(yearMonths);
+    }
+
+    void reportSendInfo(final List<String> sendInfo) {
+        log.info(String.format("Sending %s requests", sendInfo.size()));
+    }
+
+    void reportRetryInfo(final List<String> retryInfo) {
+        log.info(String.format("Retrying for %s failed requests: %s", retryInfo.size(), retryInfo));
+    }
+
+    void reportRetryResult(final List<String> sendInfo) {
+        List<String> failedAfterRetry = archivePageService.findFailedRequests();
+        List<String> successAfterRetry = successAfterRetry(sendInfo, failedAfterRetry);
+
+        log.info(String.format("Failed %s retry requests for: %s", failedAfterRetry.size(),
+            failedAfterRetry));
+        log.info(
+            String.format("Successed %s retry requests for: %s", successAfterRetry.size(),
+                successAfterRetry));
+    }
+
+    List<String> successAfterRetry(List<String> sendInfo, List<String> failedAfterRetry) {
+        List<String> successAfterRetry = new ArrayList<>();
+        for (String aSendInfo : sendInfo) {
+            if (!failedAfterRetry.contains(aSendInfo)) {
+                successAfterRetry.add(aSendInfo);
+            }
+        }
+        return successAfterRetry;
+    }
+
+    List<String> readIndexContent() {
+        return indexPageGenerator.readIndexContent();
+    }
+
+    void doGenerate(List<String> pageLinkList) {
+        indexPageGenerator.generateIndexPage(pageLinkList);
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveScheduler.java
@@ -1,84 +1,25 @@
 package org.gsh.genidxpage.scheduler;
 
-import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.service.IndexPageGenerator;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 @Component
 public class WebArchiveScheduler {
 
-    private final BulkRequestSender bulkRequestSender;
-    private final ArchivePageService archivePageService;
-    private final IndexPageGenerator indexPageGenerator;
+    private final List<WebArchiveJob> webArchiveJobs;
 
-    public WebArchiveScheduler(BulkRequestSender bulkRequestSender,
-        ArchivePageService archivePageService, IndexPageGenerator indexPageGenerator) {
-        this.bulkRequestSender = bulkRequestSender;
-        this.archivePageService = archivePageService;
-        this.indexPageGenerator = indexPageGenerator;
+    public WebArchiveScheduler(List<WebArchiveJob> webArchiveJobs) {
+        this.webArchiveJobs = webArchiveJobs;
     }
 
     @Scheduled(cron = "0 0 * * * *")
     public void scheduleSend() {
-        doSend();
-        doRetry();
-        List<String> pageLinkList = readIndexContent();
-        doGenerate(pageLinkList);
-    }
-
-    public void doSend() {
-        List<String> yearMonths = bulkRequestSender.prepareInput();
-        reportSendInfo(yearMonths);
-        bulkRequestSender.sendAll(yearMonths, archivePageService);
-    }
-
-    public void doRetry() {
-        List<String> yearMonths = archivePageService.findFailedRequests();
-        reportRetryInfo(yearMonths);
-        bulkRequestSender.sendAll(yearMonths, archivePageService);
-        reportRetryResult(yearMonths);
-    }
-
-    void reportSendInfo(final List<String> sendInfo) {
-        log.info(String.format("Sending %s requests", sendInfo.size()));
-    }
-
-    void reportRetryInfo(final List<String> retryInfo) {
-        log.info(String.format("Retrying for %s failed requests: %s", retryInfo.size(), retryInfo));
-    }
-
-    void reportRetryResult(final List<String> sendInfo) {
-        List<String> failedAfterRetry = archivePageService.findFailedRequests();
-        List<String> successAfterRetry = successAfterRetry(sendInfo, failedAfterRetry);
-
-        log.info(String.format("Failed %s retry requests for: %s", failedAfterRetry.size(),
-            failedAfterRetry));
-        log.info(
-            String.format("Successed %s retry requests for: %s", successAfterRetry.size(),
-                successAfterRetry));
-    }
-
-    List<String> successAfterRetry(List<String> sendInfo, List<String> failedAfterRetry) {
-        List<String> successAfterRetry = new ArrayList<>();
-        for (String aSendInfo : sendInfo) {
-            if (!failedAfterRetry.contains(aSendInfo)) {
-                successAfterRetry.add(aSendInfo);
-            }
+        for (WebArchiveJob webArchiveJob : webArchiveJobs) {
+            webArchiveJob.execute();
         }
-        return successAfterRetry;
-    }
-
-    List<String> readIndexContent() {
-        return indexPageGenerator.readIndexContent();
-    }
-
-    void doGenerate(List<String> pageLinkList) {
-        indexPageGenerator.generateIndexPage(pageLinkList);
     }
 }

--- a/src/main/java/org/gsh/genidxpage/scheduler/YearMonthBulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/YearMonthBulkRequestSender.java
@@ -1,0 +1,55 @@
+package org.gsh.genidxpage.scheduler;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
+import org.gsh.genidxpage.service.ArchivePageService;
+import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class YearMonthBulkRequestSender implements BulkRequestSender {
+
+    private final String inputPath;
+
+    public YearMonthBulkRequestSender(@Value("${bulk-request.input-path}") final String inputPath) {
+        this.inputPath = inputPath;
+    }
+
+    public List<String> prepareInput() {
+        ClassPathResource classPathResource = new ClassPathResource(inputPath);
+        String fileContent = "";
+
+        try {
+            Path  path = Paths.get(classPathResource.getURI());
+            fileContent = Files.readString(path, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new FailToReadRequestInputFileException(e, ErrorCode.SERVER_FAULT, "fail to read request input file");
+        }
+
+        return Arrays.stream(fileContent.strip().split("\n"))
+            .collect(ArrayList::new, List::add, List::addAll);
+    }
+
+    public void sendAll(List<String> yearMonths, ArchivePageService sender) {
+        yearMonths.forEach(yearMonth -> {
+            // 외부 서버에 요청할 입력 형식으로 파일 내용을 정제한다
+            String[] pair = yearMonth.split("/");
+            String year = pair[0];
+            String month = pair[1];
+            CheckPostArchivedDto dto = new CheckPostArchivedDto(year, month);
+
+            sender.findBlogPageLink(dto);
+        });
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/scheduler/YearMonthBulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/YearMonthBulkRequestSender.java
@@ -26,6 +26,7 @@ public class YearMonthBulkRequestSender implements BulkRequestSender {
         this.inputPath = inputPath;
     }
 
+    @Override
     public List<String> prepareInput() {
         ClassPathResource classPathResource = new ClassPathResource(inputPath);
         String fileContent = "";
@@ -41,6 +42,7 @@ public class YearMonthBulkRequestSender implements BulkRequestSender {
             .collect(ArrayList::new, List::add, List::addAll);
     }
 
+    @Override
     public void sendAll(List<String> yearMonths, ArchivePageService sender) {
         yearMonths.forEach(yearMonth -> {
             // 외부 서버에 요청할 입력 형식으로 파일 내용을 정제한다

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryIndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryIndexPageGenerator.java
@@ -32,6 +32,7 @@ public class AgileStoryIndexPageGenerator implements IndexPageGenerator {
     // TODO
     //  파일 관련 연산을 별도의 객체로 분리
     //  예외 발생 상황 테스트를 추가
+    @Override
     public void generateIndexPage(List<String> postLinksList) {
         StringBuilder builder = new StringBuilder();
         builder.append(generateHeader());
@@ -88,6 +89,7 @@ public class AgileStoryIndexPageGenerator implements IndexPageGenerator {
             """;
     }
 
+    @Override
     public List<String> readIndexContent() {
         return reader.readAllIndexContent();
     }

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryIndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryIndexPageGenerator.java
@@ -1,0 +1,94 @@
+package org.gsh.genidxpage.service;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+import org.gsh.genidxpage.exception.FailToCreateDirectoryException;
+import org.gsh.genidxpage.exception.FailToWriteFileException;
+import org.gsh.genidxpage.repository.IndexContentReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class AgileStoryIndexPageGenerator implements IndexPageGenerator {
+
+    private final String inputPath;
+    private final IndexContentReader reader;
+
+    public AgileStoryIndexPageGenerator(@Value("${index-page.path}") final String inputPath,
+        IndexContentReader reader) {
+        this.inputPath = inputPath;
+        this.reader = reader;
+    }
+
+    // TODO
+    //  파일 관련 연산을 별도의 객체로 분리
+    //  예외 발생 상황 테스트를 추가
+    public void generateIndexPage(List<String> postLinksList) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(generateHeader());
+        for (String postLinks : postLinksList) {
+            String postLinksGroupId = postLinks.split(":")[0].trim();
+            builder.append(String.format("<div class=\"post-list-id\">%s</div>", postLinksGroupId));
+
+            String postLinksHtml = Arrays.stream(postLinks.split(":")).skip(1)
+                .collect(Collectors.joining(":"));
+            for (String postLink : postLinksHtml.split("\n")) {
+                builder.append(postLink);
+                builder.append("<br>");
+                builder.append("\n");
+            }
+        }
+        builder.append(generateFooter());
+
+        Path dirPath = Path.of(inputPath);
+        try {
+            Files.createDirectories(dirPath);
+        } catch (IOException e) {
+            throw new FailToCreateDirectoryException(e, ErrorCode.SERVER_FAULT,
+                "fail to create directory to store index file");
+        }
+
+        Path filePath = Path.of(inputPath + "/index.html");
+        try {
+            Files.write(filePath, builder.toString().getBytes(), StandardOpenOption.CREATE);
+        } catch (IOException e) {
+            throw new FailToWriteFileException(e, ErrorCode.SERVER_FAULT,
+                "fail to write index file");
+        }
+    }
+
+    private String generateHeader() {
+        return """
+             <!DOCTYPE html>
+             <html>
+               <head>
+                 <meta charset="utf-8">
+                 <title>agile story blog index</title>
+                 <link rel="stylesheet" href="./index.css" type="text/css" media="screen" />
+               </head>
+               <body>
+                 <div class="site">
+            """;
+    }
+
+    private String generateFooter() {
+        return """
+                </div>
+              </body>
+            </html>
+            """;
+    }
+
+    public List<String> readIndexContent() {
+        return reader.readAllIndexContent();
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
+++ b/src/main/java/org/gsh/genidxpage/service/IndexPageGenerator.java
@@ -1,94 +1,10 @@
 package org.gsh.genidxpage.service;
 
-import org.gsh.genidxpage.common.exception.ErrorCode;
-import org.gsh.genidxpage.exception.FailToCreateDirectoryException;
-import org.gsh.genidxpage.exception.FailToWriteFileException;
-import org.gsh.genidxpage.repository.IndexContentReader;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import lombok.extern.slf4j.Slf4j;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Slf4j
-@Component
-public class IndexPageGenerator {
+public interface IndexPageGenerator {
 
-    private final String inputPath;
-    private final IndexContentReader reader;
+    void generateIndexPage(List<String> postLinksList);
 
-    public IndexPageGenerator(@Value("${index-page.path}") final String inputPath,
-        IndexContentReader reader) {
-        this.inputPath = inputPath;
-        this.reader = reader;
-    }
-
-    // TODO
-    //  파일 관련 연산을 별도의 객체로 분리
-    //  예외 발생 상황 테스트를 추가
-    public void generateIndexPage(List<String> postLinksList) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(generateHeader());
-        for (String postLinks : postLinksList) {
-            String postLinksGroupId = postLinks.split(":")[0].trim();
-            builder.append(String.format("<div class=\"post-list-id\">%s</div>", postLinksGroupId));
-
-            String postLinksHtml = Arrays.stream(postLinks.split(":")).skip(1)
-                .collect(Collectors.joining(":"));
-            for (String postLink : postLinksHtml.split("\n")) {
-                builder.append(postLink);
-                builder.append("<br>");
-                builder.append("\n");
-            }
-        }
-        builder.append(generateFooter());
-
-        Path dirPath = Path.of(inputPath);
-        try {
-            Files.createDirectories(dirPath);
-        } catch (IOException e) {
-            throw new FailToCreateDirectoryException(e, ErrorCode.SERVER_FAULT,
-                "fail to create directory to store index file");
-        }
-
-        Path filePath = Path.of(inputPath + "/index.html");
-        try {
-            Files.write(filePath, builder.toString().getBytes(), StandardOpenOption.CREATE);
-        } catch (IOException e) {
-            throw new FailToWriteFileException(e, ErrorCode.SERVER_FAULT,
-                "fail to write index file");
-        }
-    }
-
-    private String generateHeader() {
-        return """
-             <!DOCTYPE html>
-             <html>
-               <head>
-                 <meta charset="utf-8">
-                 <title>agile story blog index</title>
-                 <link rel="stylesheet" href="./index.css" type="text/css" media="screen" />
-               </head>
-               <body>
-                 <div class="site">
-            """;
-    }
-
-    private String generateFooter() {
-        return """
-                </div>
-              </body>
-            </html>
-            """;
-    }
-
-    public List<String> readIndexContent() {
-        return reader.readAllIndexContent();
-    }
+    List<String> readIndexContent();
 }

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -3,6 +3,7 @@ package org.gsh.genidxpage;
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
 import org.gsh.genidxpage.scheduler.BulkRequestSender;
+import org.gsh.genidxpage.scheduler.WebArchiveJob;
 import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
 import org.gsh.genidxpage.service.ArchivePageService;
@@ -185,8 +186,8 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
-                bulkRequestSender, service,
-                new IndexPageGenerator("/tmp/genidxpage/test", reader)
+                List.of(new WebArchiveJob(bulkRequestSender, service,
+                    new IndexPageGenerator("/tmp/genidxpage/test", reader)))
             );
 
             // 요청할 모든 입력쌍을 만든다
@@ -216,7 +217,8 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
-                bulkRequestSender, service, null
+                List.of(new WebArchiveJob(bulkRequestSender, service,
+                    new IndexPageGenerator("/tmp/genidxpage/test", reader)))
             );
 
             // 요청할 모든 입력쌍을 만든다
@@ -233,7 +235,7 @@ public class AcceptanceTest {
             });
             fakeWebArchiveServer.start();
 
-            scheduler.doSend();
+            scheduler.scheduleSend();
 
             fakeWebArchiveServer.hasReceivedMultipleRequests(requestInput.size());
             fakeWebArchiveServer.stop();
@@ -245,7 +247,8 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
-                bulkRequestSender, service, null
+                List.of(new WebArchiveJob(bulkRequestSender, service,
+                    new IndexPageGenerator("/tmp/genidxpage/test", reader)))
             );
 
             // 요청할 모든 입력쌍을 만든다
@@ -276,8 +279,7 @@ public class AcceptanceTest {
             });
             fakeWebArchiveServer.start();
 
-            scheduler.doSend();
-            scheduler.doRetry();
+            scheduler.scheduleSend();
 
             fakeWebArchiveServer.hasReceivedMultipleRequests(
                 // 접근 url을 가져오는 요청 중 비정상 응답받은 경우는 재시도한다

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -2,16 +2,17 @@ package org.gsh.genidxpage;
 
 import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.config.CustomRestTemplateBuilder;
+import org.gsh.genidxpage.repository.ArchiveStatusReporter;
+import org.gsh.genidxpage.repository.IndexContentReader;
+import org.gsh.genidxpage.repository.PostListPageRecorder;
+import org.gsh.genidxpage.repository.PostRecorder;
 import org.gsh.genidxpage.scheduler.BulkRequestSender;
 import org.gsh.genidxpage.scheduler.WebArchiveJob;
 import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
+import org.gsh.genidxpage.scheduler.YearMonthBulkRequestSender;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
 import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.repository.ArchiveStatusReporter;
-import org.gsh.genidxpage.repository.IndexContentReader;
 import org.gsh.genidxpage.service.IndexPageGenerator;
-import org.gsh.genidxpage.repository.PostListPageRecorder;
-import org.gsh.genidxpage.repository.PostRecorder;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
@@ -169,7 +170,7 @@ public class AcceptanceTest {
     class ArchivePageSchedulingTest {
         @BeforeEach
         public void setUp() {
-            bulkRequestSender = new BulkRequestSender(IGNORE_INPUT_PATH);
+            bulkRequestSender = new YearMonthBulkRequestSender(IGNORE_INPUT_PATH);
             WebArchiveApiCaller apiCaller = new WebArchiveApiCaller(
                 "http://localhost:8080",
                 "/wayback/available?url={url}&timestamp={timestamp}",

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -12,7 +12,7 @@ import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.scheduler.YearMonthBulkRequestSender;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
 import org.gsh.genidxpage.service.ArchivePageService;
-import org.gsh.genidxpage.service.IndexPageGenerator;
+import org.gsh.genidxpage.service.AgileStoryIndexPageGenerator;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.CheckPostArchivedDto;
@@ -188,7 +188,7 @@ public class AcceptanceTest {
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
                 List.of(new WebArchiveJob(bulkRequestSender, service,
-                    new IndexPageGenerator("/tmp/genidxpage/test", reader)))
+                    new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)))
             );
 
             // 요청할 모든 입력쌍을 만든다
@@ -219,7 +219,7 @@ public class AcceptanceTest {
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
                 List.of(new WebArchiveJob(bulkRequestSender, service,
-                    new IndexPageGenerator("/tmp/genidxpage/test", reader)))
+                    new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)))
             );
 
             // 요청할 모든 입력쌍을 만든다
@@ -249,7 +249,7 @@ public class AcceptanceTest {
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
                 List.of(new WebArchiveJob(bulkRequestSender, service,
-                    new IndexPageGenerator("/tmp/genidxpage/test", reader)))
+                    new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)))
             );
 
             // 요청할 모든 입력쌍을 만든다

--- a/src/test/java/org/gsh/genidxpage/scheduler/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/BulkRequestSenderTest.java
@@ -1,4 +1,4 @@
-package org.gsh.genidxpage.service;
+package org.gsh.genidxpage.scheduler;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,8 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
-import org.gsh.genidxpage.scheduler.BulkRequestSender;
-import org.gsh.genidxpage.scheduler.YearMonthBulkRequestSender;
+import org.gsh.genidxpage.service.ArchivePageService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveJobTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/WebArchiveJobTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 
-class WebArchiveSchedulerTest {
+class WebArchiveJobTest {
 
     static final List<String> IGNORE_REQUEST_INPUT = Collections.emptyList();
 
@@ -29,9 +29,9 @@ class WebArchiveSchedulerTest {
         when(sender.prepareInput()).thenReturn(IGNORE_REQUEST_INPUT);
         doNothing().when(sender).sendAll(any(), any(ArchivePageService.class));
 
-        WebArchiveScheduler scheduler = new WebArchiveScheduler(sender, service, null);
+        WebArchiveJob archiveJob = new WebArchiveJob(sender, service, null);
 
-        scheduler.doSend();
+        archiveJob.doSend();
 
         verify(sender).sendAll(any(), any(ArchivePageService.class));
     }
@@ -44,7 +44,7 @@ class WebArchiveSchedulerTest {
 
         doNothing().when(generator).generateIndexPage(any());
 
-        WebArchiveScheduler scheduler = new WebArchiveScheduler(null, null, generator);
+        WebArchiveJob scheduler = new WebArchiveJob(null, null, generator);
 
         scheduler.doGenerate(pageLinksList);
 
@@ -56,7 +56,7 @@ class WebArchiveSchedulerTest {
     public void read_index_content_from_db() {
         IndexPageGenerator generator = mock(IndexPageGenerator.class);
 
-        WebArchiveScheduler scheduler = new WebArchiveScheduler(
+        WebArchiveJob scheduler = new WebArchiveJob(
             mock(BulkRequestSender.class),
             mock(ArchivePageService.class),
             generator
@@ -75,7 +75,7 @@ class WebArchiveSchedulerTest {
 
         doNothing().when(sender).sendAll(any(), any(ArchivePageService.class));
 
-        WebArchiveScheduler scheduler = new WebArchiveScheduler(
+        WebArchiveJob scheduler = new WebArchiveJob(
             sender, service, null
         );
 
@@ -90,7 +90,7 @@ class WebArchiveSchedulerTest {
     public void get_success_fail_info_after_retry() {
         List<String> sendInfo = List.of("2020/01", "2020/02", "2020/03", "2020/04");
         List<String> failedAfterRetry = List.of("2020/01", "2020/02");
-        WebArchiveScheduler scheduler = new WebArchiveScheduler(
+        WebArchiveJob scheduler = new WebArchiveJob(
             null, null, null
         );
         Assertions.assertThat(scheduler.successAfterRetry(sendInfo, failedAfterRetry))

--- a/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/BulkRequestSenderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
 import org.gsh.genidxpage.scheduler.BulkRequestSender;
+import org.gsh.genidxpage.scheduler.YearMonthBulkRequestSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +22,7 @@ class BulkRequestSenderTest {
     @DisplayName("한 번에 여러 요청을 보낼 수 있다")
     @Test
     public void send_multiple_requests() {
-        BulkRequestSender bulkRequestSender = new BulkRequestSender(IGNORE_INPUT_PATH);
+        BulkRequestSender bulkRequestSender = new YearMonthBulkRequestSender(IGNORE_INPUT_PATH);
         ArchivePageService sender = mock(ArchivePageService.class);
 
         when(sender.findBlogPageLink(any())).thenReturn("link");
@@ -34,7 +35,7 @@ class BulkRequestSenderTest {
     @DisplayName("요청 입력 파일을 읽는 데 실패했을 경우를 처리할 수 있다")
     @Test
     public void handle_fail_to_read_request_input_file() {
-        BulkRequestSender bulkRequestSender = new BulkRequestSender(IGNORE_INPUT_PATH);
+        BulkRequestSender bulkRequestSender = new YearMonthBulkRequestSender(IGNORE_INPUT_PATH);
 
         assertThrows(
             FailToReadRequestInputFileException.class,

--- a/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/IndexPageGeneratorTest.java
@@ -24,7 +24,7 @@ class IndexPageGeneratorTest {
             "2020/05:<a href=\"https://x.net\">l2</a>",
             "2020/02:<a href=\"https://x.net\">l3</a>\n<a href=\"https://x.net\">l4</a>"
         );
-        IndexPageGenerator generator = new IndexPageGenerator("/tmp/genidxpage", null);
+        IndexPageGenerator generator = new AgileStoryIndexPageGenerator("/tmp/genidxpage", null);
         generator.generateIndexPage(pageLinksList);
         String fileContent = Files.readString(Path.of("/tmp/genidxpage/index.html"), StandardCharsets.UTF_8);
         Assertions.assertThat(fileContent).contains("l1")
@@ -37,7 +37,7 @@ class IndexPageGeneratorTest {
     @Test
     public void read_all_index_page_content_from_db() {
         IndexContentReader reader = mock(IndexContentReader.class);
-        IndexPageGenerator generator = new IndexPageGenerator(
+        IndexPageGenerator generator = new AgileStoryIndexPageGenerator(
             "/tmp/genidxpage",
             reader
         );


### PR DESCRIPTION
* WebArchiveJob 클래스를 도입한다
  - 새로운 블로그의 인덱스 페이지를 만들기 위해 새로운 BulkRequestSender,
  ArchivePageService, IndexPageGenerator 클래스를 정의해야 한다
  - WebArchiveScheduler에서 모든 인덱스 페이지를 만들 수 있게 하려면, 위 세
  타입을 갖는 기존 클래스와 새로 만들 클래스를 모두 알고 있어야 한다. 이렇게 바꿀 경우,
  doSend() 등 WebArchiveScheduler 내부에서 호출하는 메서드에 WebArchiveScheduler
  내 필드가 인자로 추가되어야 해서 유지보수가 어려워진다
  - 대신 각 블로그 인덱스 페이지 생성을 담당하는 빈을 갖는 WebArchiveJob을 정의해서
  WebArchiveScheduler는 단순히 WebArchiveJob에 요청만 하도록 한다

* BulkRequestSender, IndexPageGenerator 인터페이스를 도입한다

* WebArchiveJob 클래스 도입을 테스트에 반영한다
  - WebArchiveSchedulerTest에서 테스트하던 내용은 WebArchiveJob의 책임으로 바뀌었기
  때문에, WebArchiveSchedulerTest를 WebArchiveJobTest로 바꾼다
  - 인수 테스트에서 스케쥴러에 일괄적으로 scheduleSend()를 호출하도록 바꾼다. 원래는
  scheduleSend() 내부에서 호출되는 메서드를 쓰고 있었는데, 이 메서드가 WebArchiveJob으로
  옮겨가서 이전과 같이 호출하도록 만드는 것이 어려워졌고, 인수 테스트에서 엔트리 포인트만 호출하도록
  하는 게 테스트의 목적에 더 부합한다고 판단했다

* 소스와 테스트 패키지가 일치하도록 테스트 패키지 정리한다
