### PR TITLE
PostGroupType을 도입한다

### DIFF
--- a/config/pmd/quickstart.xml
+++ b/config/pmd/quickstart.xml
@@ -115,7 +115,12 @@
   <!-- <rule ref="category/java/codestyle.xml/UnnecessaryBoxing" /> -->
   <!-- <rule ref="category/java/codestyle.xml/UnnecessaryCast" /> -->
   <rule ref="category/java/codestyle.xml/UnnecessaryConstructor"/>
-  <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName">
+    <properties>
+      <property name="reportStaticMethods" value="false"/>
+      <property name="reportStaticFields" value="true"/>
+    </properties>
+  </rule>
   <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
   <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn"/>
   <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>

--- a/src/main/java/org/gsh/genidxpage/dao/PostGroupTypeMapper.java
+++ b/src/main/java/org/gsh/genidxpage/dao/PostGroupTypeMapper.java
@@ -1,0 +1,10 @@
+package org.gsh.genidxpage.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.gsh.genidxpage.entity.PostGroupType;
+
+@Mapper
+public interface PostGroupTypeMapper {
+
+    PostGroupType selectByGroupType(String groupType);
+}

--- a/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
+++ b/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
@@ -16,7 +16,7 @@ public class ArchiveStatus {
 
     private ArchiveStatus() {}
 
-    ArchiveStatus(String groupKey, Boolean pageExists, LocalDateTime createdAt,
+    ArchiveStatus(Long postGroupTypeId, String groupKey, Boolean pageExists, LocalDateTime createdAt,
         LocalDateTime updatedAt, LocalDateTime deletedAt) {
         this.groupKey = groupKey;
         this.pageExists = pageExists;
@@ -25,8 +25,10 @@ public class ArchiveStatus {
         this.deletedAt = deletedAt;
     }
 
-    public static ArchiveStatus createFrom(CheckPostArchived dto, Boolean pageExists) {
+    public static ArchiveStatus createFrom(CheckPostArchived dto, Boolean pageExists,
+        Long postGroupTypeId) {
         return new ArchiveStatus(
+            postGroupTypeId,
             dto.getGroupKey(),
             pageExists,
             LocalDateTime.now(),
@@ -35,8 +37,10 @@ public class ArchiveStatus {
         );
     }
 
-    public static ArchiveStatus updateFrom(ArchiveStatus archiveStatus, Boolean pageExists) {
+    public static ArchiveStatus updateFrom(Long postGroupTypeId, ArchiveStatus archiveStatus,
+        Boolean pageExists) {
         return new ArchiveStatus(
+            postGroupTypeId,
             archiveStatus.getGroupKey(),
             pageExists,
             null,

--- a/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
+++ b/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
@@ -18,6 +18,7 @@ public class ArchiveStatus {
 
     ArchiveStatus(Long postGroupTypeId, String groupKey, Boolean pageExists, LocalDateTime createdAt,
         LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        this.postGroupTypeId = postGroupTypeId;
         this.groupKey = groupKey;
         this.pageExists = pageExists;
         this.createdAt = createdAt;

--- a/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
+++ b/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
@@ -24,8 +24,8 @@ public class ArchiveStatus {
         this.deletedAt = deletedAt;
     }
 
-    public static ArchiveStatus createFrom(String groupKey, Boolean pageExists,
-        Long postGroupTypeId) {
+    public static ArchiveStatus createFrom(Long postGroupTypeId, String groupKey,
+        Boolean pageExists) {
         return new ArchiveStatus(
             postGroupTypeId,
             groupKey,

--- a/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
+++ b/src/main/java/org/gsh/genidxpage/entity/ArchiveStatus.java
@@ -1,7 +1,5 @@
 package org.gsh.genidxpage.entity;
 
-import org.gsh.genidxpage.service.dto.CheckPostArchived;
-
 import java.time.LocalDateTime;
 
 public class ArchiveStatus {
@@ -26,11 +24,11 @@ public class ArchiveStatus {
         this.deletedAt = deletedAt;
     }
 
-    public static ArchiveStatus createFrom(CheckPostArchived dto, Boolean pageExists,
+    public static ArchiveStatus createFrom(String groupKey, Boolean pageExists,
         Long postGroupTypeId) {
         return new ArchiveStatus(
             postGroupTypeId,
-            dto.getGroupKey(),
+            groupKey,
             pageExists,
             LocalDateTime.now(),
             null,

--- a/src/main/java/org/gsh/genidxpage/entity/PostGroupType.java
+++ b/src/main/java/org/gsh/genidxpage/entity/PostGroupType.java
@@ -1,0 +1,29 @@
+package org.gsh.genidxpage.entity;
+
+import java.time.LocalDateTime;
+
+public class PostGroupType {
+
+    private Long id;
+    private String groupType;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public PostGroupType(Long id, String groupType, LocalDateTime createdAt,
+        LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        this.id = id;
+        this.groupType = groupType;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getGroupType() {
+        return groupType;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
+++ b/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
@@ -27,7 +27,8 @@ public class PostListPage {
         this.deletedAt = deletedAt;
     }
 
-    public static PostListPage createFrom(Long postGroupTypeId, CheckPostArchived dto, ArchivedPageInfo archivedPageInfo) {
+    public static PostListPage createFrom(Long postGroupTypeId, CheckPostArchived dto,
+        ArchivedPageInfo archivedPageInfo) {
         return new PostListPage(
             postGroupTypeId,
             dto.getGroupKey(),

--- a/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
+++ b/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
@@ -17,8 +17,9 @@ public class PostListPage {
 
     private PostListPage() {}
 
-    PostListPage(String groupKey, String url, LocalDateTime createdAt,
+    PostListPage(Long postGroupTypeId, String groupKey, String url, LocalDateTime createdAt,
         LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        this.postGroupTypeId = postGroupTypeId;
         this.groupKey = groupKey;
         this.url = url;
         this.createdAt = createdAt;
@@ -26,8 +27,9 @@ public class PostListPage {
         this.deletedAt = deletedAt;
     }
 
-    public static PostListPage createFrom(CheckPostArchived dto, ArchivedPageInfo archivedPageInfo) {
+    public static PostListPage createFrom(Long postGroupTypeId, CheckPostArchived dto, ArchivedPageInfo archivedPageInfo) {
         return new PostListPage(
+            postGroupTypeId,
             dto.getGroupKey(),
             archivedPageInfo.accessibleUrl(),
             LocalDateTime.now(),
@@ -36,8 +38,10 @@ public class PostListPage {
         );
     }
 
-    public static PostListPage updateFrom(PostListPage postListPage, ArchivedPageInfo archivedPageInfo) {
+    public static PostListPage updateFrom(Long postGroupTypeId, PostListPage postListPage,
+        ArchivedPageInfo archivedPageInfo) {
         return new PostListPage(
+            postGroupTypeId,
             postListPage.getGroupKey(),
             archivedPageInfo.accessibleUrl(),
             null,

--- a/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
+++ b/src/main/java/org/gsh/genidxpage/entity/PostListPage.java
@@ -1,7 +1,6 @@
 package org.gsh.genidxpage.entity;
 
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
-import org.gsh.genidxpage.service.dto.CheckPostArchived;
 
 import java.time.LocalDateTime;
 
@@ -27,11 +26,11 @@ public class PostListPage {
         this.deletedAt = deletedAt;
     }
 
-    public static PostListPage createFrom(Long postGroupTypeId, CheckPostArchived dto,
+    public static PostListPage createFrom(Long postGroupTypeId, String groupKey,
         ArchivedPageInfo archivedPageInfo) {
         return new PostListPage(
             postGroupTypeId,
-            dto.getGroupKey(),
+            groupKey,
             archivedPageInfo.accessibleUrl(),
             LocalDateTime.now(),
             null,

--- a/src/main/java/org/gsh/genidxpage/exception/InvalidPostGroupTypeException.java
+++ b/src/main/java/org/gsh/genidxpage/exception/InvalidPostGroupTypeException.java
@@ -1,0 +1,19 @@
+package org.gsh.genidxpage.exception;
+
+import org.gsh.genidxpage.common.exception.ErrorCode;
+
+public class InvalidPostGroupTypeException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public InvalidPostGroupTypeException(ErrorCode errorCode, String message) {
+        super(errorCode.getReason());
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/repository/ArchiveStatusReporter.java
+++ b/src/main/java/org/gsh/genidxpage/repository/ArchiveStatusReporter.java
@@ -32,7 +32,7 @@ public class ArchiveStatusReporter {
             return;
         }
 
-        ArchiveStatus report = ArchiveStatus.createFrom(groupKey, pageExists, postGroupTypeId);
+        ArchiveStatus report = ArchiveStatus.createFrom(postGroupTypeId, groupKey, pageExists);
         reportMapper.insert(report);
     }
 

--- a/src/main/java/org/gsh/genidxpage/repository/ArchiveStatusReporter.java
+++ b/src/main/java/org/gsh/genidxpage/repository/ArchiveStatusReporter.java
@@ -32,7 +32,7 @@ public class ArchiveStatusReporter {
             return;
         }
 
-        ArchiveStatus report = ArchiveStatus.createFrom(dto, pageExists, postGroupTypeId);
+        ArchiveStatus report = ArchiveStatus.createFrom(groupKey, pageExists, postGroupTypeId);
         reportMapper.insert(report);
     }
 

--- a/src/main/java/org/gsh/genidxpage/repository/PostListPageRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/repository/PostListPageRecorder.java
@@ -35,7 +35,7 @@ public class PostListPageRecorder {
         }
 
         log.debug("inserting access url of " + archivedPageInfo.accessibleUrl());
-        PostListPage postListPage = PostListPage.createFrom(postGroupType.getId(), dto, archivedPageInfo);
+        PostListPage postListPage = PostListPage.createFrom(postGroupType.getId(), groupKey, archivedPageInfo);
         mapper.insert(postListPage);
         return postListPage.getId();
     }

--- a/src/main/java/org/gsh/genidxpage/repository/PostListPageRecorder.java
+++ b/src/main/java/org/gsh/genidxpage/repository/PostListPageRecorder.java
@@ -1,7 +1,9 @@
 package org.gsh.genidxpage.repository;
 
 import org.gsh.genidxpage.dao.PostListPageMapper;
+import org.gsh.genidxpage.entity.PostGroupType;
 import org.gsh.genidxpage.entity.PostListPage;
+import org.gsh.genidxpage.service.PostGroupTypeResolver;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
 import org.springframework.stereotype.Repository;
@@ -12,24 +14,28 @@ import lombok.extern.slf4j.Slf4j;
 public class PostListPageRecorder {
 
     private final PostListPageMapper mapper;
+    private final PostGroupTypeResolver resolver;
 
-    public PostListPageRecorder(PostListPageMapper mapper) {
+    public PostListPageRecorder(PostListPageMapper mapper, PostGroupTypeResolver resolver) {
         this.mapper = mapper;
+        this.resolver = resolver;
     }
 
     public Long record(final CheckPostArchived dto, final ArchivedPageInfo archivedPageInfo) {
-        PostListPage hasPostListPage = mapper.selectByGroupKey(dto.getGroupKey());
+        String groupKey = dto.getGroupKey();
+        PostGroupType postGroupType = resolver.resolve(groupKey);
+        PostListPage hasPostListPage = mapper.selectByGroupKey(groupKey);
 
         if (hasPostListPage != null) {
             log.debug(
                 "updating access url with id of " + hasPostListPage.getId() + " with content of "
                     + archivedPageInfo.accessibleUrl());
-            mapper.update(PostListPage.updateFrom(hasPostListPage, archivedPageInfo));
+            mapper.update(PostListPage.updateFrom(postGroupType.getId(), hasPostListPage, archivedPageInfo));
             return hasPostListPage.getId();
         }
 
         log.debug("inserting access url of " + archivedPageInfo.accessibleUrl());
-        PostListPage postListPage = PostListPage.createFrom(dto, archivedPageInfo);
+        PostListPage postListPage = PostListPage.createFrom(postGroupType.getId(), dto, archivedPageInfo);
         mapper.insert(postListPage);
         return postListPage.getId();
     }

--- a/src/main/java/org/gsh/genidxpage/service/PostGroupTypeResolver.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostGroupTypeResolver.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class PostGroupTypeResolver {
 
+    private static final String UNSUPPORTED_GROUP_TYPE = "unsupported";
     private final PostGroupTypeMapper mapper;
 
     public PostGroupTypeResolver(PostGroupTypeMapper mapper) {
@@ -15,7 +16,11 @@ public class PostGroupTypeResolver {
     }
 
     public PostGroupType resolve(String groupKey) {
-        PostGroupTypeCode code = PostGroupTypeCode.findByGroupKey(groupKey);
-        return mapper.selectByGroupType(code.getGroupType());
+        try {
+            PostGroupTypeCode code = PostGroupTypeCode.findByGroupKey(groupKey);
+            return mapper.selectByGroupType(code.getGroupType());
+        } catch (IllegalArgumentException e) {
+            return mapper.selectByGroupType(UNSUPPORTED_GROUP_TYPE);
+        }
     }
 }

--- a/src/main/java/org/gsh/genidxpage/service/PostGroupTypeResolver.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostGroupTypeResolver.java
@@ -1,0 +1,21 @@
+package org.gsh.genidxpage.service;
+
+import org.gsh.genidxpage.dao.PostGroupTypeMapper;
+import org.gsh.genidxpage.entity.PostGroupType;
+import org.gsh.genidxpage.vo.PostGroupTypeCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostGroupTypeResolver {
+
+    private final PostGroupTypeMapper mapper;
+
+    public PostGroupTypeResolver(PostGroupTypeMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public PostGroupType resolve(String groupKey) {
+        PostGroupTypeCode code = PostGroupTypeCode.findByGroupKey(groupKey);
+        return mapper.selectByGroupType(code.getGroupType());
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/PostGroupTypeResolver.java
+++ b/src/main/java/org/gsh/genidxpage/service/PostGroupTypeResolver.java
@@ -2,6 +2,7 @@ package org.gsh.genidxpage.service;
 
 import org.gsh.genidxpage.dao.PostGroupTypeMapper;
 import org.gsh.genidxpage.entity.PostGroupType;
+import org.gsh.genidxpage.exception.InvalidPostGroupTypeException;
 import org.gsh.genidxpage.vo.PostGroupTypeCode;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +20,7 @@ public class PostGroupTypeResolver {
         try {
             PostGroupTypeCode code = PostGroupTypeCode.findByGroupKey(groupKey);
             return mapper.selectByGroupType(code.getGroupType());
-        } catch (IllegalArgumentException e) {
+        } catch (InvalidPostGroupTypeException e) {
             return mapper.selectByGroupType(UNSUPPORTED_GROUP_TYPE);
         }
     }

--- a/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
+++ b/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
@@ -20,4 +20,8 @@ public enum PostGroupTypeCode {
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Invalid group key: " + groupKey));
     }
+
+    public String getGroupType() {
+        return groupType;
+    }
 }

--- a/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
+++ b/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
@@ -1,0 +1,23 @@
+package org.gsh.genidxpage.vo;
+
+import java.util.Arrays;
+
+public enum PostGroupTypeCode {
+    YEAR_MONTH("year_month", "[0-9]{4}/[0-9]{2}"),
+    CATEGORY("category", "^.+$");
+
+    private final String groupType;
+    private final String pattern;
+
+    PostGroupTypeCode(String groupType, String pattern) {
+        this.groupType = groupType;
+        this.pattern = pattern;
+    }
+
+    public static PostGroupTypeCode findByGroupKey(String groupKey) {
+        return Arrays.stream(PostGroupTypeCode.values())
+            .filter(groupType -> groupKey.matches(groupType.pattern))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Invalid group key: " + groupKey));
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
+++ b/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
@@ -1,5 +1,7 @@
 package org.gsh.genidxpage.vo;
 
+import org.gsh.genidxpage.common.exception.ErrorCode;
+import org.gsh.genidxpage.exception.InvalidPostGroupTypeException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
@@ -24,7 +26,8 @@ public enum PostGroupTypeCode {
             .findFirst()
             .orElseThrow(() -> {
                 log.warn("Could not find PostGroupTypeCode for groupKey: {}", groupKey);
-                return new IllegalArgumentException(
+                return new InvalidPostGroupTypeException(
+                    ErrorCode.SERVER_FAULT,
                     "Could not find PostGroupTypeCode for groupKey: " + groupKey
                 );
             });

--- a/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
+++ b/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
@@ -15,7 +15,8 @@ public enum PostGroupTypeCode {
     }
 
     public static PostGroupTypeCode findByGroupKey(String groupKey) {
-        return Arrays.stream(PostGroupTypeCode.values())
+        PostGroupTypeCode[] postGroupTypeCodes = PostGroupTypeCode.values();
+        return Arrays.stream(postGroupTypeCodes)
             .filter(groupType -> groupKey.matches(groupType.pattern))
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Invalid group key: " + groupKey));

--- a/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
+++ b/src/main/java/org/gsh/genidxpage/vo/PostGroupTypeCode.java
@@ -1,10 +1,13 @@
 package org.gsh.genidxpage.vo;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.Arrays;
 
+@Slf4j
 public enum PostGroupTypeCode {
     YEAR_MONTH("year_month", "[0-9]{4}/[0-9]{2}"),
-    CATEGORY("category", "^.+$");
+    CATEGORY("category", "^[\\w %&;#\\-]+$");
 
     private final String groupType;
     private final String pattern;
@@ -19,7 +22,12 @@ public enum PostGroupTypeCode {
         return Arrays.stream(postGroupTypeCodes)
             .filter(groupType -> groupKey.matches(groupType.pattern))
             .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Invalid group key: " + groupKey));
+            .orElseThrow(() -> {
+                log.warn("Could not find PostGroupTypeCode for groupKey: {}", groupKey);
+                return new IllegalArgumentException(
+                    "Could not find PostGroupTypeCode for groupKey: " + groupKey
+                );
+            });
     }
 
     public String getGroupType() {

--- a/src/main/resources/db/migration/V2_3__add_unsupported_post_group_type.sql
+++ b/src/main/resources/db/migration/V2_3__add_unsupported_post_group_type.sql
@@ -1,0 +1,3 @@
+-- 처리 불가능한 요청일 경우임을 나타내는 post_group_type을 추가한다
+INSERT INTO post_group_type (group_type, created_at)
+VALUES ('unsupported', CURRENT_DATE())

--- a/src/main/resources/mapper/ArchiveStatusMapper.xml
+++ b/src/main/resources/mapper/ArchiveStatusMapper.xml
@@ -10,7 +10,7 @@
                                        group_key,
                                        page_exists,
                                        created_at)
-    VALUES (1,
+    VALUES (#{postGroupTypeId},
             #{groupKey},
             #{pageExists},
             #{createdAt})

--- a/src/main/resources/mapper/PostGroupTypeMapper.xml
+++ b/src/main/resources/mapper/PostGroupTypeMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.gsh.genidxpage.dao.PostGroupTypeMapper">
+  <select id="selectByGroupType" resultType="org.gsh.genidxpage.entity.PostGroupType">
+    SELECT id,
+           group_type,
+           created_at,
+           updated_at,
+           deleted_at
+    FROM post_group_type
+    WHERE group_type = #{groupType}
+      AND deleted_at IS NULL
+  </select>
+</mapper>

--- a/src/main/resources/mapper/PostListPageMapper.xml
+++ b/src/main/resources/mapper/PostListPageMapper.xml
@@ -11,7 +11,7 @@
                                 group_key,
                                 url,
                                 created_at)
-    VALUES (1,
+    VALUES (#{postGroupTypeId},
             #{groupKey},
             #{url},
             #{createdAt})

--- a/src/test/java/org/gsh/genidxpage/entity/ArchiveStatusBuilder.java
+++ b/src/test/java/org/gsh/genidxpage/entity/ArchiveStatusBuilder.java
@@ -32,6 +32,7 @@ public class ArchiveStatusBuilder {
 
     public ArchiveStatus buildAsNew() {
         return new ArchiveStatus(
+            1L,
             this.groupKey,
             this.pageExists,
             LocalDateTime.now(),

--- a/src/test/java/org/gsh/genidxpage/entity/PostGroupTypeBuilder.java
+++ b/src/test/java/org/gsh/genidxpage/entity/PostGroupTypeBuilder.java
@@ -19,6 +19,11 @@ public class PostGroupTypeBuilder {
         return this;
     }
 
+    public PostGroupTypeBuilder withUnsupportedGroupType() {
+        this.groupType = "unsupported";
+        return this;
+    }
+
     public PostGroupType buildAsNew() {
         return new PostGroupType(
             1L,

--- a/src/test/java/org/gsh/genidxpage/entity/PostGroupTypeBuilder.java
+++ b/src/test/java/org/gsh/genidxpage/entity/PostGroupTypeBuilder.java
@@ -1,0 +1,31 @@
+package org.gsh.genidxpage.entity;
+
+import java.time.LocalDateTime;
+
+public class PostGroupTypeBuilder {
+
+    private Long id;
+    private String groupType;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public static PostGroupTypeBuilder builder() {
+        return new PostGroupTypeBuilder();
+    }
+
+    public PostGroupTypeBuilder withYearMonthGroupType() {
+        this.groupType = "year_month";
+        return this;
+    }
+
+    public PostGroupType buildAsNew() {
+        return new PostGroupType(
+            1L,
+            this.groupType,
+            LocalDateTime.now(),
+            null,
+            null
+        );
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/entity/PostListPageBuilder.java
+++ b/src/test/java/org/gsh/genidxpage/entity/PostListPageBuilder.java
@@ -27,6 +27,7 @@ public class PostListPageBuilder {
 
     public PostListPage buildAsNew() {
         return new PostListPage(
+            1L,
             this.groupKey,
             this.url,
             LocalDateTime.now(),

--- a/src/test/java/org/gsh/genidxpage/repository/ArchiveStatusReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/repository/ArchiveStatusReporterTest.java
@@ -10,6 +10,9 @@ import org.assertj.core.api.Assertions;
 import org.gsh.genidxpage.dao.ArchiveStatusMapper;
 import org.gsh.genidxpage.entity.ArchiveStatus;
 import org.gsh.genidxpage.entity.ArchiveStatusBuilder;
+import org.gsh.genidxpage.entity.PostGroupType;
+import org.gsh.genidxpage.entity.PostGroupTypeBuilder;
+import org.gsh.genidxpage.service.PostGroupTypeResolver;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
 import org.gsh.genidxpage.service.dto.CheckYearMonthPostArchivedDto;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +26,8 @@ class ArchiveStatusReporterTest {
     @Test
     public void check_url_exists_in_web_archive_for_given_year_month() {
         ArchiveStatusMapper mapper = mock(ArchiveStatusMapper.class);
-        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
+        PostGroupTypeResolver resolver = mock(PostGroupTypeResolver.class);
+        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper, resolver);
         ArchiveStatus report = ArchiveStatusBuilder.builder()
             .withGroupKey("2021/03")
             .thatExists()
@@ -41,15 +45,20 @@ class ArchiveStatusReporterTest {
     @Test
     public void only_update_status_when_page_status_already_inserted() {
         ArchiveStatusMapper mapper = mock(ArchiveStatusMapper.class);
-        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
+        PostGroupTypeResolver resolver = mock(PostGroupTypeResolver.class);
+        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper, resolver);
         ArchiveStatus report = ArchiveStatusBuilder.builder()
             .withGroupKey("2021/03")
             .thatExists()
+            .buildAsNew();
+        PostGroupType postGroupType = PostGroupTypeBuilder.builder()
+            .withYearMonthGroupType()
             .buildAsNew();
 
         when(mapper.selectByGroupKey(any())).thenReturn(
             report);
         doNothing().when(mapper).update(report);
+        when(resolver.resolve(any())).thenReturn(postGroupType);
 
         CheckPostArchived dto = new CheckYearMonthPostArchivedDto("2021/03");
         reporter.reportArchivedPageSearch(dto, Boolean.TRUE);
@@ -62,7 +71,8 @@ class ArchiveStatusReporterTest {
     @Test
     public void read_all_failed_request_info_from_db() {
         ArchiveStatusMapper mapper = mock(ArchiveStatusMapper.class);
-        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper);
+        PostGroupTypeResolver resolver = mock(PostGroupTypeResolver.class);
+        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper, resolver);
         List<ArchiveStatus> failRequestReports = List.of(
             ArchiveStatusBuilder.builder()
                 .withGroupKey("2020/05")

--- a/src/test/java/org/gsh/genidxpage/repository/ArchiveStatusReporterTest.java
+++ b/src/test/java/org/gsh/genidxpage/repository/ArchiveStatusReporterTest.java
@@ -46,7 +46,7 @@ class ArchiveStatusReporterTest {
     public void only_update_status_when_page_status_already_inserted() {
         ArchiveStatusMapper mapper = mock(ArchiveStatusMapper.class);
         PostGroupTypeResolver resolver = mock(PostGroupTypeResolver.class);
-        ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper, resolver);
+        final ArchiveStatusReporter reporter = new ArchiveStatusReporter(mapper, resolver);
         ArchiveStatus report = ArchiveStatusBuilder.builder()
             .withGroupKey("2021/03")
             .thatExists()

--- a/src/test/java/org/gsh/genidxpage/repository/PostListPageRecorderTest.java
+++ b/src/test/java/org/gsh/genidxpage/repository/PostListPageRecorderTest.java
@@ -6,8 +6,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.gsh.genidxpage.dao.PostListPageMapper;
+import org.gsh.genidxpage.entity.PostGroupType;
+import org.gsh.genidxpage.entity.PostGroupTypeBuilder;
 import org.gsh.genidxpage.entity.PostListPage;
 import org.gsh.genidxpage.entity.PostListPageBuilder;
+import org.gsh.genidxpage.service.PostGroupTypeResolver;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.ArchivedPageInfoBuilder;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
@@ -21,12 +24,19 @@ class PostListPageRecorderTest {
     @Test
     public void record_post_list_page_url_to_db() {
         PostListPageMapper mapper = mock(PostListPageMapper.class);
-        PostListPageRecorder recorder = new PostListPageRecorder(mapper);
+        PostGroupTypeResolver resolver = mock(PostGroupTypeResolver.class);
+        PostListPageRecorder recorder = new PostListPageRecorder(mapper, resolver);
 
         CheckPostArchived dto = new CheckYearMonthPostArchivedDto("2021/03");
         ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()
             .withAccessibleArchivedSnapshots()
             .build();
+        PostGroupType postGroupType = PostGroupTypeBuilder.builder()
+            .withYearMonthGroupType()
+            .buildAsNew();
+
+        when(resolver.resolve(any())).thenReturn(postGroupType);
+
         recorder.record(dto, archivedPageInfo);
 
         verify(mapper).insert(any(PostListPage.class));
@@ -36,13 +46,19 @@ class PostListPageRecorderTest {
     @Test
     public void only_update_when_already_inserted_url_of_year_month() {
         PostListPageMapper mapper = mock(PostListPageMapper.class);
-        PostListPageRecorder recorder = new PostListPageRecorder(mapper);
+        PostGroupTypeResolver resolver = mock(PostGroupTypeResolver.class);
+        PostListPageRecorder recorder = new PostListPageRecorder(mapper, resolver);
 
         PostListPage postListPage = PostListPageBuilder.builder()
             .withGroupKey("2021/03")
             .withUrl("http://localhost:8080/web/20230614220926/archives/2021/03")
             .buildAsNew();
+        PostGroupType postGroupType = PostGroupTypeBuilder.builder()
+            .withYearMonthGroupType()
+            .buildAsNew();
+
         when(mapper.selectByGroupKey(any())).thenReturn(postListPage);
+        when(resolver.resolve(any())).thenReturn(postGroupType);
 
         CheckPostArchived dto = new CheckYearMonthPostArchivedDto("2021/03");
         ArchivedPageInfo archivedPageInfo = ArchivedPageInfoBuilder.builder()

--- a/src/test/java/org/gsh/genidxpage/service/PostGroupTypeResolverTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostGroupTypeResolverTest.java
@@ -1,0 +1,31 @@
+package org.gsh.genidxpage.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.api.Assertions;
+import org.gsh.genidxpage.dao.PostGroupTypeMapper;
+import org.gsh.genidxpage.entity.PostGroupType;
+import org.gsh.genidxpage.entity.PostGroupTypeBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostGroupTypeResolverTest {
+
+    @DisplayName("dto로부터 postGroupType 정보를 가져올 수 있다")
+    @Test
+    public void resolve_group_type_from_dto() {
+        PostGroupTypeMapper mapper = mock(PostGroupTypeMapper.class);
+        PostGroupTypeResolver resolver = new PostGroupTypeResolver(mapper);
+
+        PostGroupType postGroupType = PostGroupTypeBuilder.builder()
+            .withYearMonthGroupType()
+            .buildAsNew();
+        when(mapper.selectByGroupType(any())).thenReturn(postGroupType);
+
+        PostGroupType expectedPostGroupType = resolver.resolve("2022/03");
+
+        Assertions.assertThat(expectedPostGroupType.getGroupType()).isEqualTo("year_month");
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/service/PostGroupTypeResolverTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/PostGroupTypeResolverTest.java
@@ -2,6 +2,7 @@ package org.gsh.genidxpage.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
@@ -27,5 +28,21 @@ class PostGroupTypeResolverTest {
         PostGroupType expectedPostGroupType = resolver.resolve("2022/03");
 
         Assertions.assertThat(expectedPostGroupType.getGroupType()).isEqualTo("year_month");
+    }
+
+    @DisplayName("postGroupType 정보를 가져오지 못한 경우")
+    @Test
+    public void fail_to_retrieve_group_type_from_dto() {
+        PostGroupTypeMapper mapper = mock(PostGroupTypeMapper.class);
+        PostGroupTypeResolver resolver = new PostGroupTypeResolver(mapper);
+
+        PostGroupType postGroupType = PostGroupTypeBuilder.builder()
+            .withUnsupportedGroupType()
+            .buildAsNew();
+        when(mapper.selectByGroupType(any())).thenReturn(postGroupType);
+
+        resolver.resolve("***");
+
+        verify(mapper).selectByGroupType(any());
     }
 }

--- a/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
+++ b/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
@@ -1,0 +1,26 @@
+package org.gsh.genidxpage.vo;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class PostGroupTypeCodeTest {
+
+    @DisplayName("주어진 값의 형식에 연관된 그룹 타입을 찾아낼 수 있다")
+    @Test
+    public void find_group_type_matching_given_value() {
+        String yearMonthGroupKey = "2021/12";
+        Assertions.assertThat(PostGroupTypeCode.findByGroupKey(yearMonthGroupKey))
+            .isEqualTo(PostGroupTypeCode.YEAR_MONTH);
+
+        List.of(
+            "Concept %26amp%3B Principle", "Domain-Driven Design", "Software Design"
+        ).forEach(categoryGroupKey -> {
+                Assertions.assertThat(PostGroupTypeCode.findByGroupKey(categoryGroupKey))
+                    .isEqualTo(PostGroupTypeCode.CATEGORY);
+            }
+        );
+    }
+}

--- a/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
+++ b/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
@@ -3,6 +3,7 @@ package org.gsh.genidxpage.vo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.gsh.genidxpage.exception.InvalidPostGroupTypeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +27,7 @@ class PostGroupTypeCodeTest {
         List.of(
             "***", "///", ":::"
         ).forEach(unsupportedGroupKey -> assertThrows(
-                IllegalArgumentException.class,
+            InvalidPostGroupTypeException.class,
                 () -> PostGroupTypeCode.findByGroupKey(unsupportedGroupKey)
             )
         );

--- a/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
+++ b/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
@@ -1,6 +1,7 @@
 package org.gsh.genidxpage.vo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,14 @@ class PostGroupTypeCodeTest {
             "Concept %26amp%3B Principle", "Domain-Driven Design", "Software Design"
         ).forEach(categoryGroupKey -> assertThat(PostGroupTypeCode.findByGroupKey(categoryGroupKey))
             .isEqualTo(PostGroupTypeCode.CATEGORY)
+        );
+
+        List.of(
+            "***", "///", ":::"
+        ).forEach(unsupportedGroupKey -> assertThrows(
+                IllegalArgumentException.class,
+                () -> PostGroupTypeCode.findByGroupKey(unsupportedGroupKey)
+            )
         );
     }
 }

--- a/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
+++ b/src/test/java/org/gsh/genidxpage/vo/PostGroupTypeCodeTest.java
@@ -1,6 +1,7 @@
 package org.gsh.genidxpage.vo;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,15 +13,13 @@ class PostGroupTypeCodeTest {
     @Test
     public void find_group_type_matching_given_value() {
         String yearMonthGroupKey = "2021/12";
-        Assertions.assertThat(PostGroupTypeCode.findByGroupKey(yearMonthGroupKey))
+        assertThat(PostGroupTypeCode.findByGroupKey(yearMonthGroupKey))
             .isEqualTo(PostGroupTypeCode.YEAR_MONTH);
 
         List.of(
             "Concept %26amp%3B Principle", "Domain-Driven Design", "Software Design"
-        ).forEach(categoryGroupKey -> {
-                Assertions.assertThat(PostGroupTypeCode.findByGroupKey(categoryGroupKey))
-                    .isEqualTo(PostGroupTypeCode.CATEGORY);
-            }
+        ).forEach(categoryGroupKey -> assertThat(PostGroupTypeCode.findByGroupKey(categoryGroupKey))
+            .isEqualTo(PostGroupTypeCode.CATEGORY)
         );
     }
 }


### PR DESCRIPTION
* PostGroupType을 도입한다
  - PostGroupTypeResolver는 PostGroupTypeCode와 PostGroupTypeMapper에
    물어서 주어진 dto에 연관된 PostGroupType을 반환한다
  - year, month를 일반화한 groupKey가 어떤 postGroupType에 속하는지 알 수 있도록,
    db에 ArchiveStatus, PostListPage 기록 시 dto와 연관된 postGroupType을 가져와
    해당 postGroupType의 id를 같이 기록한다

* PostGroupType을 알아내지 못했을 경우에 대한 처리
  - 주어진 요청에 대한 PostGroupType을 찾지 못했을 경우, 1) 로그를 남기고,
    2) InvalidPostGroupTypeException 예외를 던지고, 3) 해당 요청을 지원하지 않음을
    나타내는 PostGroupType을 반환한다. 이 객체는 상위 레이어로 넘겨져서 기존 실행
    흐름을 깨지지 않게 하고, db에 기록된다
  - db의 post_group_type 테이블에 지원 불가를 나타내는 PostGroupType을 추가한다

* layered architecture를 따르도록, 엔티티 레이어에서 dto에 대한 의존을 없앤다
