### PR TITLE
Refactor/fake server

### DIFF
--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -276,11 +276,8 @@ public class AcceptanceTest {
                 .filter(ym -> !"2021".equals(ym.split("/")[0]))
                 .toList();
             failRequests.forEach(yearMonth -> {
-                String[] pair = yearMonth.split("/");
-                String year = pair[0];
-                String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 비정상 응답한다
-                fakeWebArchiveServer.respondItHasNoArchivedPageFor(year, month);
+                fakeWebArchiveServer.respondItHasNoArchivedPageFor(yearMonth);
             });
             fakeWebArchiveServer.start();
 

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -93,7 +93,7 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             fakeWebArchiveServer.respondItHasArchivedPage();
-            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(
+            fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(
                 "2021/03", false
             );
 
@@ -119,7 +119,7 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             fakeWebArchiveServer.respondItHasArchivedPage();
-            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(
+            fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(
                 "2021/03", true
             );
 
@@ -147,7 +147,7 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             fakeWebArchiveServer.respondItHasArchivedPage();
-            fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(
+            fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(
                 "2021/03", false
             );
             fakeWebArchiveServer.start();
@@ -202,7 +202,7 @@ public class AcceptanceTest {
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
-                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(yearMonth, false);
+                fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(yearMonth, false);
             });
             fakeWebArchiveServer.start();
 
@@ -236,7 +236,7 @@ public class AcceptanceTest {
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
-                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(yearMonth, false);
+                fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(yearMonth, false);
             });
             fakeWebArchiveServer.start();
 
@@ -269,7 +269,7 @@ public class AcceptanceTest {
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 정상 응답한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
-                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(yearMonth, false);
+                fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(yearMonth, false);
             });
             // 비정상 응답할 입력을 설정한다
             List<String> failRequests = requestInput.stream()

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -201,7 +201,7 @@ public class AcceptanceTest {
                 String year = pair[0];
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
-                fakeWebArchiveServer.respondItHasArchivedPageFor(year, month);
+                fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
                 fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
             });
             fakeWebArchiveServer.start();
@@ -235,7 +235,7 @@ public class AcceptanceTest {
                 String year = pair[0];
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
-                fakeWebArchiveServer.respondItHasArchivedPageFor(year, month);
+                fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
                 fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
             });
             fakeWebArchiveServer.start();
@@ -268,7 +268,7 @@ public class AcceptanceTest {
                 String year = pair[0];
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 정상 응답한다
-                fakeWebArchiveServer.respondItHasArchivedPageFor(year, month);
+                fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
                 fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
             });
             // 비정상 응답할 입력을 설정한다

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -94,7 +94,7 @@ public class AcceptanceTest {
 
             fakeWebArchiveServer.respondItHasArchivedPage();
             fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(
-                "2021", "03", false
+                "2021/03", false
             );
 
             fakeWebArchiveServer.start();
@@ -120,7 +120,7 @@ public class AcceptanceTest {
 
             fakeWebArchiveServer.respondItHasArchivedPage();
             fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(
-                "2021", "03", true
+                "2021/03", true
             );
 
             fakeWebArchiveServer.start();
@@ -132,7 +132,7 @@ public class AcceptanceTest {
 
             // web archive server는 주어진 연월의 블로그 글 목록 페이지를 반환한다
             Assertions.assertThat(response.getBody()).isEqualTo(
-                "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">2021년 03월 첫 AC2 과정 40기가 곧 열립니다</a>\n"
+                "<a href=\"https://web.archive.org/web/20230614220926/http://agile.egloos.com/5946833\">2021/03 첫 AC2 과정 40기가 곧 열립니다</a>\n"
                     + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5932600\">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a>\n"
                     + "<a href=\"https://web.archive.org/web/20230614124528/http://agile.egloos.com/5931859\">혹독한 조언이 나를 살릴까?</a>"
             );
@@ -148,7 +148,7 @@ public class AcceptanceTest {
 
             fakeWebArchiveServer.respondItHasArchivedPage();
             fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(
-                "2021", "03", false
+                "2021/03", false
             );
             fakeWebArchiveServer.start();
 
@@ -202,7 +202,7 @@ public class AcceptanceTest {
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
-                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
+                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(yearMonth, false);
             });
             fakeWebArchiveServer.start();
 
@@ -236,7 +236,7 @@ public class AcceptanceTest {
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
-                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
+                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(yearMonth, false);
             });
             fakeWebArchiveServer.start();
 
@@ -269,7 +269,7 @@ public class AcceptanceTest {
                 String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 정상 응답한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
-                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(year, month, false);
+                fakeWebArchiveServer.respondBlogPostListInGivenYearMonth(yearMonth, false);
             });
             // 비정상 응답할 입력을 설정한다
             List<String> failRequests = requestInput.stream()

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -197,9 +197,6 @@ public class AcceptanceTest {
 
             // 요청할 모든 입력쌍을 만든다
             List.of("2021/03", "2020/05").forEach(yearMonth -> {
-                String[] pair = yearMonth.split("/");
-                String year = pair[0];
-                String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
                 fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(yearMonth, false);
@@ -231,9 +228,6 @@ public class AcceptanceTest {
 
             // 입력쌍의 갯수만큼 요청을 보낸다
             requestInput.forEach(yearMonth -> {
-                String[] pair = yearMonth.split("/");
-                String year = pair[0];
-                String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
                 fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(yearMonth, false);
@@ -264,9 +258,6 @@ public class AcceptanceTest {
                 .filter(ym -> "2021".equals(ym.split("/")[0]))
                 .toList();
             passRequests.forEach(yearMonth -> {
-                String[] pair = yearMonth.split("/");
-                String year = pair[0];
-                String month = pair[1];
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 정상 응답한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
                 fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(yearMonth, false);

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -115,29 +115,28 @@ public class FakeWebArchiveServer {
         respondItHasArchivedPageFor("2021", "03");
     }
 
-    public void respondItHasNoArchivedPageFor(String year, String month) {
+    public void respondItHasNoArchivedPageFor(String groupKey) {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
             .withQueryParam("url", matching(
-                String.format("http[s]?://agile.egloos.com/archives/%s/%s",
-                    year,
-                    month
+                String.format("http[s]?://agile.egloos.com/archives/%s",
+                    groupKey
                 )
             ))
             .withQueryParam("timestamp", matching("[0-9]{8}"))
             .willReturn(aResponse().withStatus(200).withBody(
                 String.format("""
                     {
-                      "url": "agile.egloos.com/archives/%s/%s",
+                      "url": "agile.egloos.com/archives/%s",
                       "archived_snapshots": {}
                     }
-                    """, year, month)
+                    """, groupKey)
                 )
             )
         );
     }
 
     public void respondItHasNoArchivedPage() {
-        respondItHasNoArchivedPageFor("1999", "07");
+        respondItHasNoArchivedPageFor("1999/07");
     }
 
     public void hasReceivedMultipleRequests(int requestCount) {

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -32,13 +32,13 @@ public class FakeWebArchiveServer {
             .withPathParam("month", matching(month))
             .willReturn(aResponse().withStatus(200)
                 .withBody(
-                    buildPostListPage(year, month, hasManyPost)
+                    buildPostListPage(year + "/" + month, hasManyPost)
                 ).withHeader("Content-Type", "text/html; charset=utf-8")
             )
         );
     }
 
-    private String buildPostListPage(String year, String month, boolean hasManyPost) {
+    private String buildPostListPage(String groupKey, boolean hasManyPost) {
         String postListPageHead = """
             <html>
             <table border="0" cellpadding="0" cellspacing="0" align="CENTER" width="100%">
@@ -74,8 +74,8 @@ public class FakeWebArchiveServer {
         String firstPostTemplate = """
             <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">YEAR/MONTH/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">YEAR년 MONTH월 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
             """;
-        String firstPost = firstPostTemplate.replaceAll("YEAR", year)
-            .replaceAll("MONTH", month);
+        String firstPost = firstPostTemplate.replaceAll("YEAR", groupKey.split("/")[0])
+            .replaceAll("MONTH", groupKey.split("/")[1]);
         String otherPosts = """
             <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
             <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/27</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -87,32 +87,32 @@ public class FakeWebArchiveServer {
     }
 
 
-    public void respondItHasArchivedPageFor(String year, String month) {
+    public void respondItHasArchivedPageFor(String groupKey) {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))
-            .withQueryParam("url", matching(String.format("http[s]?://agile.egloos.com/archives/%s/%s", year, month)))
+            .withQueryParam("url", matching(String.format("http[s]?://agile.egloos.com/archives/%s", groupKey)))
             .withQueryParam("timestamp", matching("[0-9]{8}"))
             .willReturn(aResponse().withStatus(200).withBody(
                     String.format("""
                         {
-                          "url": "agile.egloos.com/archives/%s/%s",
+                          "url": "agile.egloos.com/archives/%s",
                           "archived_snapshots": {
                             "closest": {
                               "status": "200",
                               "available": true,
-                              "url": "http://localhost:8080/web/20230614220926/archives/%s/%s",
+                              "url": "http://localhost:8080/web/20230614220926/archives/%s",
                               "timestamp": "20230614220926"
                             }
                           },
                           "timestamp": "20240101"
                         }
-                        """, year, month, year, month)
+                        """, groupKey, groupKey)
                 )
             )
         );
     }
 
     public void respondItHasArchivedPage() {
-        respondItHasArchivedPageFor("2021", "03");
+        respondItHasArchivedPageFor("2021/03");
     }
 
     public void respondItHasNoArchivedPageFor(String groupKey) {

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -25,14 +25,13 @@ public class FakeWebArchiveServer {
         this.instance.stop();
     }
 
-    public void respondBlogPostListInGivenYearMonth(String year, String month,
+    public void respondBlogPostListInGivenYearMonth(String groupKey,
         boolean hasManyPost) {
-        instance.stubFor(get(urlPathTemplate("/web/20230614220926/archives/{year}/{month}"))
-            .withPathParam("year", matching(year))
-            .withPathParam("month", matching(month))
+        instance.stubFor(get(urlPathTemplate("/web/20230614220926/archives"))
+            .withQueryParam("groupKey", matching(groupKey))
             .willReturn(aResponse().withStatus(200)
                 .withBody(
-                    buildPostListPage(year + "/" + month, hasManyPost)
+                    buildPostListPage(groupKey, hasManyPost)
                 ).withHeader("Content-Type", "text/html; charset=utf-8")
             )
         );
@@ -72,10 +71,10 @@ public class FakeWebArchiveServer {
             """;
 
         String firstPostTemplate = """
-            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">YEAR/MONTH/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">YEAR년 MONTH월 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">GROUPKEY/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">GROUPKEY 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
             """;
-        String firstPost = firstPostTemplate.replaceAll("YEAR", groupKey.split("/")[0])
-            .replaceAll("MONTH", groupKey.split("/")[1]);
+        String firstPost = firstPostTemplate.replaceAll("GROUPKEY", groupKey);
+
         String otherPosts = """
             <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
             <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/27</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
@@ -99,7 +98,7 @@ public class FakeWebArchiveServer {
                             "closest": {
                               "status": "200",
                               "available": true,
-                              "url": "http://localhost:8080/web/20230614220926/archives/%s",
+                              "url": "http://localhost:8080/web/20230614220926/archives?groupKey=%s",
                               "timestamp": "20230614220926"
                             }
                           },
@@ -159,10 +158,9 @@ public class FakeWebArchiveServer {
 
     public void hasReceivedMultiplePostListPageRequests(int requestCount) {
         instance.verify(requestCount,
-            getRequestedFor(urlPathTemplate("/web/{timestamp}/archives/{year}/{month}"))
+            getRequestedFor(urlPathTemplate("/web/{timestamp}/archives"))
+                .withQueryParam("groupKey", matching("[12][0-9]{3}/[01][0-9]"))
                 .withPathParam("timestamp", matching("[0-9]{14}"))
-                .withPathParam("year", matching("[12][0-9]{3}"))
-                .withPathParam("month", matching("[01][0-9]"))
         );
     }
 }

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -25,7 +25,7 @@ public class FakeWebArchiveServer {
         this.instance.stop();
     }
 
-    public void respondBlogPostListInGivenYearMonth(String groupKey,
+    public void respondBlogPostListInGivenGroupKey(String groupKey,
         boolean hasManyPost) {
         instance.stubFor(get(urlPathTemplate("/web/20230614220926/archives"))
             .withQueryParam("groupKey", matching(groupKey))


### PR DESCRIPTION
* FakeWebArchiveServer가 고정된 형식이 아닌 여러 groupKey에 적절히 응답할 수 있도록 바꾼다
  - year, month 값을 groupKey로 한 번에 받도록 바꾼다
  - query parameter로 groupKey를 받도록 바꾼다. 기존과 같이 path parameter로 groupKey를 받으면,
  연월 형식 groupKey에 포함된 '/' 문자 때문에 파싱에 실패한다. 인코딩할 경우, fake server와 서버가 주고받는
  url의 path parameter를 모두 인코딩해야 한다. 대신 query parameter로 groupKey를 받도록 바꿔서
  인코딩 처리할 필요 없도록 만든다
