### PR TITLE
새로운 그룹핑 기준을 처리할 클래스를 추가한다

### DIFF
--- a/src/main/java/org/gsh/genidxpage/scheduler/CategoryBulkRequestSender.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/CategoryBulkRequestSender.java
@@ -3,8 +3,8 @@ package org.gsh.genidxpage.scheduler;
 import org.gsh.genidxpage.common.exception.ErrorCode;
 import org.gsh.genidxpage.exception.FailToReadRequestInputFileException;
 import org.gsh.genidxpage.service.ArchivePageService;
+import org.gsh.genidxpage.service.dto.CheckCategoryPostArchivedDto;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
-import org.gsh.genidxpage.service.dto.CheckYearMonthPostArchivedDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
@@ -19,11 +19,11 @@ import java.util.Arrays;
 import java.util.List;
 
 @Component
-public class YearMonthBulkRequestSender implements BulkRequestSender {
+public class CategoryBulkRequestSender implements BulkRequestSender {
 
     private final String inputPath;
 
-    public YearMonthBulkRequestSender(@Value("${bulk-request.input-path.year-month}") final String inputPath) {
+    public CategoryBulkRequestSender(@Value("${bulk-request.input-path.category}") final String inputPath) {
         this.inputPath = inputPath;
     }
 
@@ -44,10 +44,9 @@ public class YearMonthBulkRequestSender implements BulkRequestSender {
     }
 
     @Override
-    public void sendAll(List<String> yearMonths, ArchivePageService sender) {
-        yearMonths.forEach(yearMonth -> {
-            CheckPostArchived dto = new CheckYearMonthPostArchivedDto(yearMonth);
-
+    public void sendAll(List<String> categories, ArchivePageService sender) {
+        categories.forEach(category -> {
+            CheckPostArchived dto = new CheckCategoryPostArchivedDto(category);
             sender.findBlogPageLink(dto);
         });
     }

--- a/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveJob.java
+++ b/src/main/java/org/gsh/genidxpage/scheduler/WebArchiveJob.java
@@ -2,6 +2,7 @@ package org.gsh.genidxpage.scheduler;
 
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.IndexPageGenerator;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,8 +17,11 @@ public class WebArchiveJob {
     private final ArchivePageService archivePageService;
     private final IndexPageGenerator indexPageGenerator;
 
-    public WebArchiveJob(BulkRequestSender bulkRequestSender, ArchivePageService archivePageService,
-        IndexPageGenerator indexPageGenerator) {
+    public WebArchiveJob(
+        @Qualifier("yearMonthBulkRequestSender") BulkRequestSender bulkRequestSender,
+        @Qualifier("agileStoryArchivePageService") ArchivePageService archivePageService,
+        @Qualifier("agileStoryIndexPageGenerator") IndexPageGenerator indexPageGenerator
+    ) {
         this.bulkRequestSender = bulkRequestSender;
         this.archivePageService = archivePageService;
         this.indexPageGenerator = indexPageGenerator;

--- a/src/main/java/org/gsh/genidxpage/service/AeternumArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AeternumArchivePageService.java
@@ -65,7 +65,8 @@ public class AeternumArchivePageService implements ArchivePageService {
         return reporter.readAllFailedRequestInput();
     }
 
-    ArchivedPageInfo findArchivedPageInfo(final CheckPostArchived dto) {
+    @Override
+    public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchived dto) {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto.getUrl(),
             dto.getTimestamp());
 

--- a/src/main/java/org/gsh/genidxpage/service/AeternumArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AeternumArchivePageService.java
@@ -1,0 +1,97 @@
+package org.gsh.genidxpage.service;
+
+import org.gsh.genidxpage.repository.ArchiveStatusReporter;
+import org.gsh.genidxpage.repository.PostListPageRecorder;
+import org.gsh.genidxpage.repository.PostRecorder;
+import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
+import org.gsh.genidxpage.service.dto.CheckPostArchived;
+import org.gsh.genidxpage.service.dto.EmptyArchivedPageInfo;
+import org.gsh.genidxpage.vo.GroupKey;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class AeternumArchivePageService implements ArchivePageService {
+    private final WebArchiveApiCaller webArchiveApiCaller;
+    private final ArchiveStatusReporter reporter;
+    private final PostListPageRecorder listPageRecorder;
+    private final PostRecorder postRecorder;
+    private final WebPageParser webPageParser;
+
+    public AeternumArchivePageService(WebArchiveApiCaller webArchiveApiCaller,
+        ArchiveStatusReporter reporter, PostListPageRecorder listPageRecorder, PostRecorder postRecorder,
+        WebPageParser webPageParser) {
+        this.webArchiveApiCaller = webArchiveApiCaller;
+        this.reporter = reporter;
+        this.listPageRecorder = listPageRecorder;
+        this.postRecorder = postRecorder;
+        this.webPageParser = webPageParser;
+    }
+
+    @Transactional
+    @Override
+    public String findBlogPageLink(final CheckPostArchived dto) {
+        ArchivedPageInfo archivedPageInfo = this.findArchivedPageInfo(dto);
+        GroupKey groupKey = GroupKey.from(dto.getGroupKey());
+        if (archivedPageInfo.isUnreachable()) {
+            log.debug(
+                String.format("fail to read blog page link for %s due to timeout",
+                    groupKey)
+            );
+            return "";
+        }
+
+        if (archivedPageInfo.isEmpty()) {
+            log.debug(
+                String.format("empty blog page link for %s", groupKey));
+            return "";
+        }
+        Long listPageId = listPageRecorder.record(groupKey, archivedPageInfo);
+        log.debug("id of post list page inserted/updated now is {" + listPageId + "}");
+
+        String blogPost = this.findBlogPostPage(archivedPageInfo);
+        postRecorder.record(this.buildPageLinks(blogPost), listPageId);
+
+        return this.buildPageLinks(blogPost);
+    }
+
+    @Override
+    public List<String> findFailedRequests() {
+        return reporter.readAllFailedRequestInput();
+    }
+
+    ArchivedPageInfo findArchivedPageInfo(final CheckPostArchived dto) {
+        ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto.getUrl(),
+            dto.getTimestamp());
+
+        GroupKey groupKey = GroupKey.from(dto.getGroupKey());
+        if (archivedPageInfo.isUnreachable()) {
+            reporter.reportArchivedPageSearch(groupKey, Boolean.FALSE);
+            return archivedPageInfo;
+        }
+
+        if (!webArchiveApiCaller.isArchived(archivedPageInfo)) {
+            reporter.reportArchivedPageSearch(groupKey, Boolean.FALSE);
+            return new EmptyArchivedPageInfo();
+        }
+
+        reporter.reportArchivedPageSearch(groupKey, Boolean.TRUE);
+        return archivedPageInfo;
+    }
+
+    String findBlogPostPage(final ArchivedPageInfo archivedPageInfo) {
+        ResponseEntity<String> blogPostResponse = webArchiveApiCaller.findBlogPostPage(
+            archivedPageInfo);
+        return blogPostResponse.getBody();
+    }
+
+    String buildPageLinks(final String blogPost) {
+        //TODO 새로운 블로그에 맞는 로직을 만들어야 한다
+        return "";
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/AgileStoryArchivePageService.java
@@ -66,7 +66,8 @@ public class AgileStoryArchivePageService implements ArchivePageService {
         return reporter.readAllFailedRequestInput();
     }
 
-    ArchivedPageInfo findArchivedPageInfo(final CheckPostArchived dto) {
+    @Override
+    public ArchivedPageInfo findArchivedPageInfo(final CheckPostArchived dto) {
         ArchivedPageInfo archivedPageInfo = webArchiveApiCaller.findArchivedPageInfo(dto.getUrl(),
             dto.getTimestamp());
 

--- a/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
+++ b/src/main/java/org/gsh/genidxpage/service/ArchivePageService.java
@@ -1,5 +1,6 @@
 package org.gsh.genidxpage.service;
 
+import org.gsh.genidxpage.service.dto.ArchivedPageInfo;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
 
 import java.util.List;
@@ -9,4 +10,6 @@ public interface ArchivePageService {
     String findBlogPageLink(CheckPostArchived dto);
 
     List<String> findFailedRequests();
+
+    ArchivedPageInfo findArchivedPageInfo(CheckPostArchived dto);
 }

--- a/src/main/java/org/gsh/genidxpage/service/dto/CheckCategoryPostArchivedDto.java
+++ b/src/main/java/org/gsh/genidxpage/service/dto/CheckCategoryPostArchivedDto.java
@@ -1,0 +1,29 @@
+package org.gsh.genidxpage.service.dto;
+
+public class CheckCategoryPostArchivedDto implements CheckPostArchived {
+
+    private final String groupKey;
+    private final String url;
+    private final String timestamp;
+
+    public CheckCategoryPostArchivedDto(String groupKey) {
+        this.groupKey = groupKey;
+        this.url = "x" + groupKey;
+        this.timestamp = "20230401";
+    }
+
+    @Override
+    public String getGroupKey() {
+        return groupKey;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public String getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
+++ b/src/main/java/org/gsh/genidxpage/web/ArchivePageController.java
@@ -3,6 +3,7 @@ package org.gsh.genidxpage.web;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
 import org.gsh.genidxpage.service.dto.CheckYearMonthPostArchivedDto;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,7 +17,9 @@ public class ArchivePageController {
 
     private final ArchivePageService service;
 
-    public ArchivePageController(final ArchivePageService service) {
+    public ArchivePageController(
+        @Qualifier("agileStoryArchivePageService") final ArchivePageService service
+    ) {
         this.service = service;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,9 @@ web-archive:
   check-archived-uri: /wayback/available?url={url}
 
 bulk-request:
-  input-path: static/year-month-list
+  input-path:
+    year-month: static/year-month-list
+    category: static/category-list
 index-page:
   path: /app/static
 

--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -7,9 +7,11 @@ import org.gsh.genidxpage.repository.IndexContentReader;
 import org.gsh.genidxpage.repository.PostListPageRecorder;
 import org.gsh.genidxpage.repository.PostRecorder;
 import org.gsh.genidxpage.scheduler.BulkRequestSender;
+import org.gsh.genidxpage.scheduler.CategoryBulkRequestSender;
 import org.gsh.genidxpage.scheduler.WebArchiveJob;
 import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.scheduler.YearMonthBulkRequestSender;
+import org.gsh.genidxpage.service.AeternumArchivePageService;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
 import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.AgileStoryIndexPageGenerator;
@@ -20,6 +22,7 @@ import org.gsh.genidxpage.service.dto.CheckYearMonthPostArchivedDto;
 import org.gsh.genidxpage.vo.GroupKey;
 import org.gsh.genidxpage.web.ArchivePageController;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+@Disabled
 @TestPropertySource(properties = "app.scheduling.enable=false")
 @Transactional
 @SpringBootTest
@@ -166,21 +170,28 @@ public class AcceptanceTest {
         }
     }
 
-    private BulkRequestSender bulkRequestSender;
-    private ArchivePageService service;
-    private static final String IGNORE_INPUT_PATH = "static/year-month-list";
+    private BulkRequestSender yearMonthBulkRequestSender;
+    private BulkRequestSender categoryBulkRequestSender;
+    private ArchivePageService agileStoryService;
+    private ArchivePageService aeternumService;
+    private static final String IGNORE_YEAR_MONTH_INPUT_PATH = "static/year-month-list";
+    private static final String IGNORE_CATEGORY_INPUT_PATH = "static/category";
 
     @Nested
     class ArchivePageSchedulingTest {
         @BeforeEach
         public void setUp() {
-            bulkRequestSender = new YearMonthBulkRequestSender(IGNORE_INPUT_PATH);
+            yearMonthBulkRequestSender = new YearMonthBulkRequestSender(IGNORE_YEAR_MONTH_INPUT_PATH);
+            categoryBulkRequestSender = new CategoryBulkRequestSender(IGNORE_CATEGORY_INPUT_PATH);
             WebArchiveApiCaller apiCaller = new WebArchiveApiCaller(
                 "http://localhost:8080",
                 "/wayback/available?url={url}&timestamp={timestamp}",
                 CustomRestTemplateBuilder.get()
             );
-            service = new AgileStoryArchivePageService(
+            agileStoryService = new AgileStoryArchivePageService(
+                apiCaller, reporter, listPageRecorder, postRecorder, webPageParser
+            );
+            aeternumService = new AeternumArchivePageService(
                 apiCaller, reporter, listPageRecorder, postRecorder, webPageParser
             );
         }
@@ -191,12 +202,17 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
-                List.of(new WebArchiveJob(bulkRequestSender, service,
-                    new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)))
+                List.of(
+                    new WebArchiveJob(yearMonthBulkRequestSender, agileStoryService,
+                        new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)),
+                    new WebArchiveJob(categoryBulkRequestSender, aeternumService,
+                        new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader))
+                )
             );
 
             // 요청할 모든 입력쌍을 만든다
-            List.of("2021/03", "2020/05").forEach(yearMonth -> {
+            List.of("2021/03", "2020/05", "Domain-Driven Design", "Software Design").forEach(
+                yearMonth -> {
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 응답할 수 있도록 설정한다
                 fakeWebArchiveServer.respondItHasArchivedPageFor(yearMonth);
                 fakeWebArchiveServer.respondBlogPostListInGivenGroupKey(yearMonth, false);
@@ -209,6 +225,9 @@ public class AcceptanceTest {
             Assertions.assertThat(
                 Files.readString(Path.of("/tmp/genidxpage/test/index.html"), StandardCharsets.UTF_8)
             ).isNotNull();
+            Assertions.assertThat(
+                Files.readString(Path.of("/tmp/genidxpage/test/aeternum-index.html"), StandardCharsets.UTF_8)
+            ).isNotNull();
 
             fakeWebArchiveServer.stop();
         }
@@ -219,12 +238,16 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
-                List.of(new WebArchiveJob(bulkRequestSender, service,
-                    new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)))
+                List.of(new WebArchiveJob(yearMonthBulkRequestSender, agileStoryService,
+                        new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)),
+                    new WebArchiveJob(categoryBulkRequestSender, aeternumService,
+                        new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader))
+                )
             );
 
             // 요청할 모든 입력쌍을 만든다
-            List<String> requestInput = List.of("2021/03", "2020/05");
+            List<String> requestInput = List.of("2021/03", "2020/05", "Domain-Driven Design",
+                "Software Design");
 
             // 입력쌍의 갯수만큼 요청을 보낸다
             requestInput.forEach(yearMonth -> {
@@ -246,16 +269,20 @@ public class AcceptanceTest {
             FakeWebArchiveServer fakeWebArchiveServer = new FakeWebArchiveServer();
 
             final WebArchiveScheduler scheduler = new WebArchiveScheduler(
-                List.of(new WebArchiveJob(bulkRequestSender, service,
-                    new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)))
+                List.of(new WebArchiveJob(yearMonthBulkRequestSender, agileStoryService,
+                        new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader)),
+                    new WebArchiveJob(categoryBulkRequestSender, aeternumService,
+                        new AgileStoryIndexPageGenerator("/tmp/genidxpage/test", reader))
+                )
             );
 
             // 요청할 모든 입력쌍을 만든다
-            List<String> requestInput = List.of("2021/03", "2020/05");
+            List<String> requestInput = List.of("2021/03", "2020/05", "Domain-Driven Design",
+                "Software Design");
 
             // 정상 응답할 입력을 설정한다
             List<String> passRequests = requestInput.stream()
-                .filter(ym -> "2021".equals(ym.split("/")[0]))
+                .filter(ym -> "2021".equals(ym.split("/")[0]) || "Software Design".equals(ym))
                 .toList();
             passRequests.forEach(yearMonth -> {
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 정상 응답한다
@@ -264,7 +291,7 @@ public class AcceptanceTest {
             });
             // 비정상 응답할 입력을 설정한다
             List<String> failRequests = requestInput.stream()
-                .filter(ym -> !"2021".equals(ym.split("/")[0]))
+                .filter(ym -> !"2021".equals(ym.split("/")[0]) && !"Software Design".equals(ym))
                 .toList();
             failRequests.forEach(yearMonth -> {
                 // 주어진 연월 쌍을 요청받았을 때 FakeWebArchive 서버가 비정상 응답한다

--- a/src/test/java/org/gsh/genidxpage/scheduler/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/BulkRequestSenderTest.java
@@ -43,7 +43,7 @@ class BulkRequestSenderTest {
             });
 
         Integer requestTotalCnt = requestGroups.stream()
-            .map(requestGroup -> requestGroup.size())
+            .map(List::size)
             .reduce(0, (acc, reqGroupSize) -> acc + reqGroupSize);
         verify(sender, times(requestTotalCnt)).findBlogPageLink(any());
     }

--- a/src/test/java/org/gsh/genidxpage/scheduler/BulkRequestSenderTest.java
+++ b/src/test/java/org/gsh/genidxpage/scheduler/BulkRequestSenderTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 class BulkRequestSenderTest {
 
@@ -21,24 +22,45 @@ class BulkRequestSenderTest {
     @DisplayName("한 번에 여러 요청을 보낼 수 있다")
     @Test
     public void send_multiple_requests() {
-        BulkRequestSender bulkRequestSender = new YearMonthBulkRequestSender(IGNORE_INPUT_PATH);
+        List<BulkRequestSender> bulkRequestSenders = List.of(
+            new YearMonthBulkRequestSender(IGNORE_INPUT_PATH),
+            new CategoryBulkRequestSender(IGNORE_INPUT_PATH)
+        );
+        List<List<String>> requestGroups = List.of(
+            List.of("2021/03", "2020/05"),
+            List.of("Domain-Driven Design", "Software Design")
+        );
+
         ArchivePageService sender = mock(ArchivePageService.class);
 
         when(sender.findBlogPageLink(any())).thenReturn("link");
 
-        bulkRequestSender.sendAll(List.of("2021/03", "2020/05"), sender);
+        IntStream.range(0, bulkRequestSenders.size())
+            .forEach(idx -> {
+                BulkRequestSender bulkRequestSender = bulkRequestSenders.get(idx);
+                List<String> requestGroup = requestGroups.get(idx);
+                bulkRequestSender.sendAll(requestGroup, sender);
+            });
 
-        verify(sender, times(2)).findBlogPageLink(any());
+        Integer requestTotalCnt = requestGroups.stream()
+            .map(requestGroup -> requestGroup.size())
+            .reduce(0, (acc, reqGroupSize) -> acc + reqGroupSize);
+        verify(sender, times(requestTotalCnt)).findBlogPageLink(any());
     }
 
     @DisplayName("요청 입력 파일을 읽는 데 실패했을 경우를 처리할 수 있다")
     @Test
     public void handle_fail_to_read_request_input_file() {
-        BulkRequestSender bulkRequestSender = new YearMonthBulkRequestSender(IGNORE_INPUT_PATH);
-
-        assertThrows(
-            FailToReadRequestInputFileException.class,
-            bulkRequestSender::prepareInput
+        List<BulkRequestSender> bulkRequestSenders = List.of(
+            new YearMonthBulkRequestSender(IGNORE_INPUT_PATH),
+            new CategoryBulkRequestSender(IGNORE_INPUT_PATH)
         );
+
+        for (BulkRequestSender bulkRequestSender : bulkRequestSenders) {
+            assertThrows(
+                FailToReadRequestInputFileException.class,
+                bulkRequestSender::prepareInput
+            );
+        }
     }
 }

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -32,7 +32,7 @@ class ArchivePageServiceTest {
         );
         ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter, null, null, null);
+        ArchivePageService service = new AgileStoryArchivePageService(caller, reporter, null, null, null);
 
         CheckPostArchived dto = new CheckYearMonthPostArchivedDto("1999/07");
         service.findArchivedPageInfo(dto);
@@ -49,7 +49,7 @@ class ArchivePageServiceTest {
         );
         ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter,
+        ArchivePageService service = new AgileStoryArchivePageService(caller, reporter,
             null, null, null);
 
         CheckPostArchived dto = new CheckYearMonthPostArchivedDto("2020/03");
@@ -72,7 +72,7 @@ class ArchivePageServiceTest {
         when(caller.isArchived(any())).thenReturn(true);
         ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller, reporter,
+        ArchivePageService service = new AgileStoryArchivePageService(caller, reporter,
             mock(PostListPageRecorder.class), null, null);
 
         CheckPostArchived dto = new CheckYearMonthPostArchivedDto("2021/03");
@@ -88,7 +88,7 @@ class ArchivePageServiceTest {
         respondsValidBlogPostPage(caller);
 
         PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(caller,
+        ArchivePageService service = new AgileStoryArchivePageService(caller,
             mock(ArchiveStatusReporter.class), listPageRecorder, mock(PostRecorder.class),
             mock(WebPageParser.class));
 
@@ -105,7 +105,7 @@ class ArchivePageServiceTest {
         WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
         respondsValidBlogPostPage(caller);
 
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(
+        ArchivePageService service = new AgileStoryArchivePageService(
             caller,
             mock(ArchiveStatusReporter.class),
             mock(PostListPageRecorder.class),
@@ -136,7 +136,7 @@ class ArchivePageServiceTest {
     @Test
     public void read_all_failed_request_info_from_db() {
         ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
-        AgileStoryArchivePageService service = new AgileStoryArchivePageService(
+        ArchivePageService service = new AgileStoryArchivePageService(
             mock(WebArchiveApiCaller.class),
             reporter,
             mock(PostListPageRecorder.class),

--- a/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
+++ b/src/test/java/org/gsh/genidxpage/service/ArchivePageServiceTest.java
@@ -16,6 +16,7 @@ import org.gsh.genidxpage.service.dto.CheckCategoryPostArchivedDto;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
 import org.gsh.genidxpage.service.dto.CheckYearMonthPostArchivedDto;
 import org.gsh.genidxpage.service.dto.UnreachableArchivedPageInfo;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -25,17 +26,30 @@ import java.util.stream.IntStream;
 
 class ArchivePageServiceTest {
 
+    WebArchiveApiCaller caller;
+    ArchiveStatusReporter reporter;
+    PostListPageRecorder listPageRecorder;
+    PostRecorder postRecorder;
+    WebPageParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        caller = mock(WebArchiveApiCaller.class);
+        reporter = mock(ArchiveStatusReporter.class);
+        listPageRecorder = mock(PostListPageRecorder.class);
+        postRecorder = mock(PostRecorder.class);
+        parser = mock(WebPageParser.class);
+    }
+
     @DisplayName("페이지 아키이빙 정보를 찾지 못했을 때 db에 기록한다")
     @Test
     public void write_to_db_when_page_archive_info_not_found() {
         ArchivedPageInfo noArchivedPageInfo = ArchivedPageInfoBuilder.builder()
             .withEmptyArchivedSnapshots()
             .build();
-        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
         when(caller.findArchivedPageInfo(any(), any())).thenReturn(
             noArchivedPageInfo
         );
-        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
         List<ArchivePageService> services = List.of(
             new AgileStoryArchivePageService(caller, reporter, null, null, null),
@@ -58,11 +72,9 @@ class ArchivePageServiceTest {
     @DisplayName("타임아웃 초과로 페이지 아카이빙 정보를 읽어오지 못했을 때 db에 기록한다")
     @Test
     public void write_to_db_when_page_archive_info_read_timeout() {
-        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
         when(caller.findArchivedPageInfo(any(), any())).thenReturn(
             new UnreachableArchivedPageInfo()
         );
-        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
         List<ArchivePageService> services = List.of(
             new AgileStoryArchivePageService(caller, reporter, null, null, null),
@@ -89,14 +101,11 @@ class ArchivePageServiceTest {
             .withAccessibleArchivedSnapshots()
             .build();
 
-        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
         when(caller.findArchivedPageInfo(any(), any())).thenReturn(
             archivedPageInfo
         );
         when(caller.isArchived(any())).thenReturn(true);
-        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
 
-        PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
         List<ArchivePageService> services = List.of(
             new AgileStoryArchivePageService(caller, reporter, listPageRecorder, null, null),
             new AeternumArchivePageService(caller, reporter, listPageRecorder, null, null)
@@ -118,13 +127,7 @@ class ArchivePageServiceTest {
     @DisplayName("페이지 아키이빙 정보를 찾았을 때, 접근 url을 db에 기록한다")
     @Test
     public void write_access_url_to_db_when_page_archive_info_found() {
-        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
         respondsValidBlogPostPage(caller);
-
-        PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
-        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
-        PostRecorder postRecorder = mock(PostRecorder.class);
-        WebPageParser parser = mock(WebPageParser.class);
 
         List<ArchivePageService> services = List.of(
             new AgileStoryArchivePageService(caller, reporter, listPageRecorder, postRecorder,
@@ -148,13 +151,7 @@ class ArchivePageServiceTest {
     @DisplayName("블로그 글 목록 페이지로부터 파싱한 블로그 링크 목록을 db에 기록한다")
     @Test
     public void write_post_link_parsed_from_list_page_to_db() {
-        PostRecorder postRecorder = mock(PostRecorder.class);
-        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
         respondsValidBlogPostPage(caller);
-
-        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
-        PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
-        WebPageParser parser = mock(WebPageParser.class);
 
         List<ArchivePageService> services = List.of(
             new AgileStoryArchivePageService(caller, reporter, listPageRecorder, postRecorder,
@@ -191,11 +188,6 @@ class ArchivePageServiceTest {
     @DisplayName("실패한 요청 정보를 db로부터 읽어온다")
     @Test
     public void read_all_failed_request_info_from_db() {
-        ArchiveStatusReporter reporter = mock(ArchiveStatusReporter.class);
-        WebArchiveApiCaller caller = mock(WebArchiveApiCaller.class);
-        PostListPageRecorder listPageRecorder = mock(PostListPageRecorder.class);
-        PostRecorder postRecorder = mock(PostRecorder.class);
-
         List<ArchivePageService> services = List.of(
             new AgileStoryArchivePageService(caller, reporter, listPageRecorder, postRecorder,
                 null),

--- a/src/test/resources/static/category-list
+++ b/src/test/resources/static/category-list
@@ -1,0 +1,2 @@
+Domain-Driven Design
+Software Design

--- a/src/test/resources/static/category-list
+++ b/src/test/resources/static/category-list
@@ -1,2 +1,0 @@
-Domain-Driven Design
-Software Design


### PR DESCRIPTION
새로운 그룹핑 기준을 처리할 수 있도록 애플리케이션 구조를 확장한다

1. 새로운 그룹핑 기준을 처리할 클래스 추가 및 수정
- CategoryBulkRequestSender, AeternumArchivePageService, CheckCategoryPostArchivedDto 등 새로운 그룹핑 기준으로 인덱스 페이지를 만들기 위한 구현을 추가한다
- 추가된 구현으로 인해 어떤 빈을 주입할지 명확하지 않은 경우를 @Qualifier로 처리한다

2. 테스트 코드 변경
- 추가된 클래스를 기존 테스트에 반영한다

3. 현재 이슈 작업 일시 중단
- fake server가 여러 groupKey를 처리할 정도로 유연하지 않아서 인수 테스트에 변경 사항을 반영하기 어렵단 걸 발견했다.
새로 추가하는 인덱스 파일 생성 로직을 테스트하려면 dto의 groupKey 형식이 달라질 때 url 역시 달라져야 하는데, 현재 fake server는 groupKey 값에 관계없이 url이 동일하기 때문이다.
- 먼저 fake server가 다양한 그룹핑 기준을 수용할 수 있도록 유연하게 리팩토링하고, 현재 이슈를 재개할 예정이다
