### PR TITLE
새로운 그룹핑 기준을 처리할 수 있게 fake server를 유연하게 만든다

### DIFF
--- a/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
+++ b/src/test/java/org/gsh/genidxpage/AcceptanceTest.java
@@ -11,8 +11,8 @@ import org.gsh.genidxpage.scheduler.WebArchiveJob;
 import org.gsh.genidxpage.scheduler.WebArchiveScheduler;
 import org.gsh.genidxpage.scheduler.YearMonthBulkRequestSender;
 import org.gsh.genidxpage.service.AgileStoryArchivePageService;
-import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.AgileStoryIndexPageGenerator;
+import org.gsh.genidxpage.service.ArchivePageService;
 import org.gsh.genidxpage.service.WebArchiveApiCaller;
 import org.gsh.genidxpage.service.WebPageParser;
 import org.gsh.genidxpage.service.dto.CheckPostArchived;
@@ -236,7 +236,7 @@ public class AcceptanceTest {
 
             scheduler.scheduleSend();
 
-            fakeWebArchiveServer.hasReceivedMultipleRequests(requestInput.size());
+            fakeWebArchiveServer.hasReceivedMultipleRequests(requestInput);
             fakeWebArchiveServer.stop();
         }
 
@@ -276,9 +276,9 @@ public class AcceptanceTest {
 
             fakeWebArchiveServer.hasReceivedMultipleRequests(
                 // 접근 url을 가져오는 요청 중 비정상 응답받은 경우는 재시도한다
-                passRequests.size() + failRequests.size() * 2,
+                failRequests,
                 // 블로그 목록 페이지를 가져오는 요청 중 재시도한 요청은 또 다시 실패한다
-                passRequests.size()
+                passRequests
             );
 
             fakeWebArchiveServer.stop();

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -9,6 +9,12 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 public class FakeWebArchiveServer {
 
     WireMockServer instance;
@@ -38,53 +44,22 @@ public class FakeWebArchiveServer {
     }
 
     private String buildPostListPage(String groupKey, boolean hasManyPost) {
-        String postListPageHead = """
-            <html>
-            <table border="0" cellpadding="0" cellspacing="0" align="CENTER" width="100%">
-              <tr><td valign="TOP" width="90%">
-                <div id="LEFT">
-                  <!-- egloos content start -->
-                  <div class="POST">
-                    <div class="POST_HEAD">
-                      <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                        <tr><td width="80%"><div class="POST_TTL">2021년 03월 전체 글 목록</div></td>
-                          <td width="20%" align="RIGHT"></td></tr>
-                      </table>
-                    </div>
-                    <div class="POST_BODY">
-            """;
-        String postListPageTail = """
-                      <div style="margin-top:10px;"><a href="/web/20230614220926/http://agile.egloos.com/archives/2021/03/page/1" title="전체보기">"2021년03월" 의 글 내용 전체 보기</a></div>
-                    </div>
-                    <div class="POST_TAIL"></div>
-
-                  </div><!-- egloos content end -->
-                  <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                    <tr><td align="RIGHT" width="48%">&lt; 이전페이지</td><td width="4%"></td>
-                      <td align="LEFT" width="48%">다음페이지 &gt;</td></tr>
-                  </table>
-                  <br><br>
-                </div>
-              </td>
-            </table>
-            </html>
-            """;
-
-        String firstPostTemplate = """
-            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">GROUPKEY/22</span> &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">GROUPKEY 첫 AC2 과정 40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[3]</span><br/>
-            """;
-        String firstPost = firstPostTemplate.replaceAll("GROUPKEY", groupKey);
-
-        String otherPosts = """
-            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/25</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 : 마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate"></span><br>
-            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/27</span> &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a> <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
-            """;
+        String stringPath;
         if (hasManyPost) {
-            return postListPageHead + firstPost + otherPosts + postListPageTail;
+            stringPath = "src/test/resources/year-month-multiple-post-list-page.html";
+        } else {
+            stringPath = "src/test/resources/year-month-one-post-list-page.html";
         }
-        return postListPageHead + firstPost + postListPageTail;
-    }
 
+        try {
+            Path path = Paths.get(stringPath);
+            String fileContent = Files.readString(path, StandardCharsets.UTF_8);
+            return fileContent;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 
     public void respondItHasArchivedPageFor(String groupKey) {
         instance.stubFor(get(urlPathTemplate("/wayback/available"))

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -42,13 +42,13 @@ public class FakeWebArchiveServer {
             .withQueryParam("groupKey", matching(groupKey))
             .willReturn(aResponse().withStatus(200)
                 .withBody(
-                    buildPostListPage(groupKey, hasManyPost)
+                    buildPostListPage(hasManyPost) // TODO groupKey에 따라 다른 페이지를 반환하도록 변경해야 한다
                 ).withHeader("Content-Type", "text/html; charset=utf-8")
             )
         );
     }
 
-    private String buildPostListPage(String groupKey, boolean hasManyPost) {
+    private String buildPostListPage(boolean hasManyPost) {
         String stringPath;
         if (hasManyPost) {
             stringPath = "src/test/resources/year-month-multiple-post-list-page.html";
@@ -58,8 +58,7 @@ public class FakeWebArchiveServer {
 
         try {
             Path path = Paths.get(stringPath);
-            String fileContent = Files.readString(path, StandardCharsets.UTF_8);
-            return fileContent;
+            return Files.readString(path, StandardCharsets.UTF_8);
         } catch (IOException e) {
             e.printStackTrace();
             return null;

--- a/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
+++ b/src/test/java/org/gsh/genidxpage/FakeWebArchiveServer.java
@@ -175,37 +175,37 @@ public class FakeWebArchiveServer {
             );
         }
     }
-}
 
-class MatcherInfo {
+    private static class MatcherInfo {
 
-    private final String scheme;
-    private final String host;
-    private final String pattern;
+        private final String scheme;
+        private final String host;
+        private final String pattern;
 
-    public MatcherInfo(final String scheme, final String host, String pattern) {
-        this.scheme = scheme;
-        this.host = host;
-        this.pattern = pattern;
-    }
-
-    static MatcherInfo parse(String groupKey) {
-        if (groupKey.matches("[12][0-9]{3}/[01][0-9]")) {
-            return new MatcherInfo("https", "agile.egloos.com/archives/",
-                "[12][0-9]{3}/[01][0-9]");
+        public MatcherInfo(final String scheme, final String host, String pattern) {
+            this.scheme = scheme;
+            this.host = host;
+            this.pattern = pattern;
         }
-        return new MatcherInfo("https", "aeternum.egloos.com/category/", ".*");
-    }
 
-    String url() {
-        return scheme + "://" + host;
-    }
+        static MatcherInfo parse(String groupKey) {
+            if (groupKey.matches("[12][0-9]{3}/[01][0-9]")) {
+                return new MatcherInfo("https", "agile.egloos.com/archives/",
+                    "[12][0-9]{3}/[01][0-9]");
+            }
+            return new MatcherInfo("https", "aeternum.egloos.com/category/", ".*");
+        }
 
-    String urlNoScheme() {
-        return host;
-    }
+        String url() {
+            return scheme + "://" + host;
+        }
 
-    public String getPattern() {
-        return pattern;
+        String urlNoScheme() {
+            return host;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
     }
 }

--- a/src/test/java/org/gsh/genidxpage/apistudy/ApiStudyTest.java
+++ b/src/test/java/org/gsh/genidxpage/apistudy/ApiStudyTest.java
@@ -1,0 +1,24 @@
+package org.gsh.genidxpage.apistudy;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ApiStudyTest {
+
+    @DisplayName("정규식 패턴을 기준으로 그룹핑할 수 있다")
+    @Test
+    public void group_by_pattern() {
+        String regex = "[12][0-9]{3}/[01][0-9]";
+        List<String> list = List.of("2021/03", "2020/05", "other");
+        Map<Boolean, List<String>> groups = list.stream()
+            .collect(Collectors.groupingBy(groupKey -> Pattern.matches(regex, groupKey)));
+        Assertions.assertThat(groups.get(true)).hasSameElementsAs(List.of("2021/03", "2020/05"));
+        Assertions.assertThat(groups.get(false)).hasSameElementsAs(List.of("other"));
+    }
+}

--- a/src/test/resources/year-month-multiple-post-list-page.html
+++ b/src/test/resources/year-month-multiple-post-list-page.html
@@ -1,0 +1,47 @@
+<html>
+<table border="0" cellpadding="0" cellspacing="0" align="CENTER" width="100%">
+  <tr>
+    <td valign="TOP" width="90%">
+      <div id="LEFT">
+        <!-- egloos content start -->
+        <div class="POST">
+          <div class="POST_HEAD">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tr>
+                <td width="80%">
+                  <div class="POST_TTL">2021년 03월 전체 글 목록</div>
+                </td>
+                <td width="20%" align="RIGHT"></td>
+              </tr>
+            </table>
+          </div>
+          <div class="POST_BODY">
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/22</span>
+            &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">2021/03 첫 AC2 과정
+            40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;"
+                                  class="archivedate">[3]</span><br/>
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/25</span>
+            &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5932600">AC2 온라인 과정 :
+            마인크래프트로 함께 자라기를 배운다</a> <span style="font-size: 8pt; color: #9b9b9b;"
+                                          class="archivedate"></span><br>
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/27</span>
+            &nbsp; <a href="/web/20230614124528/http://agile.egloos.com/5931859">혹독한 조언이 나를 살릴까?</a>
+            <span style="font-size: 8pt; color: #9b9b9b;" class="archivedate">[13]</span><br>
+            <div style="margin-top:10px;"><a
+                href="/web/20230614220926/http://agile.egloos.com/archives/2021/03/page/1"
+                title="전체보기">"2021년03월" 의 글 내용 전체 보기</a></div>
+          </div>
+          <div class="POST_TAIL"></div>
+        </div><!-- egloos content end -->
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+          <tr>
+            <td align="RIGHT" width="48%">&lt; 이전페이지</td>
+            <td width="4%"></td>
+            <td align="LEFT" width="48%">다음페이지 &gt;</td>
+          </tr>
+        </table>
+        <br><br>
+      </div>
+    </td>
+</table>
+</html>

--- a/src/test/resources/year-month-one-post-list-page.html
+++ b/src/test/resources/year-month-one-post-list-page.html
@@ -1,0 +1,40 @@
+<html>
+<table border="0" cellpadding="0" cellspacing="0" align="CENTER" width="100%">
+  <tr>
+    <td valign="TOP" width="90%">
+      <div id="LEFT">
+        <!-- egloos content start -->
+        <div class="POST">
+          <div class="POST_HEAD">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tr>
+                <td width="80%">
+                  <div class="POST_TTL">2021년 03월 전체 글 목록</div>
+                </td>
+                <td width="20%" align="RIGHT"></td>
+              </tr>
+            </table>
+          </div>
+          <div class="POST_BODY">
+            <span style="font-size: 90%; color: #9b9b9b;" class="archivedate">2021/03/22</span>
+            &nbsp; <a href="/web/20230614220926/http://agile.egloos.com/5946833">2021/03 첫 AC2 과정
+            40기가 곧 열립니다</a> <span style="font-size: 8pt; color: #9b9b9b;"
+                                  class="archivedate">[3]</span><br/>
+            <div style="margin-top:10px;"><a
+                href="/web/20230614220926/http://agile.egloos.com/archives/2021/03/page/1"
+                title="전체보기">"2021년03월" 의 글 내용 전체 보기</a></div>
+          </div>
+          <div class="POST_TAIL"></div>
+        </div><!-- egloos content end -->
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+          <tr>
+            <td align="RIGHT" width="48%">&lt; 이전페이지</td>
+            <td width="4%"></td>
+            <td align="LEFT" width="48%">다음페이지 &gt;</td>
+          </tr>
+        </table>
+        <br><br>
+      </div>
+    </td>
+</table>
+</html>


### PR DESCRIPTION
새로운 그룹핑 기준을 처리할 수 있도록 fake server를 유연하게 만든다

- 그룹핑 기준이 추가됨에 따라, fake server가 유효하다고 판단해야 하는 요청 정보도 그룹핑 기준에 따라 바뀌어야 한다. 요청 정보는 scheme을 포함/포함하지 않는 블로그 url, groupKey를 매칭할 수 있는 패턴 등 다양하고, 그룹핑 기준에 따라 값이 달라진다. 이런 정보를 알아낼 수 있는 MatcherInfo 클래스를 구현해서 관련된 책임을 MatcherInfo 한곳으로 모은다.

- hasReceivedMultipleRequests()가 여러 그룹핑 기준의 요청을 처리할 수 있게 하기 위해, 요청 갯수 대신 요청 목록 자체를 받게 하고, 메서드 내에서 동일한 그룹핑 기준을 갖는 요청끼리 묶어서 처리한다.
